### PR TITLE
fix(cdk): force Lambda code update on every CI deploy via commit SHA asset hash

### DIFF
--- a/infra/stack/mockserverstack.go
+++ b/infra/stack/mockserverstack.go
@@ -23,7 +23,7 @@ func MockServerStack(scope constructs.Construct, id string, props *awscdk.StackP
 		Handler:      jsii.String("bootstrap"),
 		Architecture: lambdaArchitecture(),
 		FunctionName: jsii.String("mock-server" + suffix),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/mockserver"), nil),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/mockserver"), lambdaAssetOptions()),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),
 	})
 

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslogs"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awss3"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awss3assets"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssns"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssnssubscriptions"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
@@ -34,6 +35,20 @@ func lambdaArchitecture() awslambda.Architecture {
 		return awslambda.Architecture_X86_64()
 	}
 	return awslambda.Architecture_ARM_64()
+}
+
+// lambdaAssetOptions returns asset options that force a new upload on every CI deploy.
+// When COMMIT_SHA is set (i.e. in GitHub Actions), CDK uses it as a custom hash so
+// CloudFormation always sees a changed S3 key and updates the Lambda code.
+// Locally (no COMMIT_SHA), CDK falls back to its default content-hash behavior.
+func lambdaAssetOptions() *awss3assets.AssetOptions {
+	if sha := os.Getenv("COMMIT_SHA"); sha != "" {
+		return &awss3assets.AssetOptions{
+			AssetHash:     jsii.String(sha),
+			AssetHashType: awscdk.AssetHashType_CUSTOM,
+		}
+	}
+	return nil
 }
 
 func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaStackProps) awscdk.Stack {
@@ -168,7 +183,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 			Handler: jsii.String("bootstrap"),
 			Code: awslambda.Code_FromAsset(
 				jsii.String("../lambda-build/"+lowerName),
-				nil,
+				lambdaAssetOptions(),
 			),
 			FunctionName: jsii.String(kebabName + suffix),
 			Architecture: lambdaArchitecture(),
@@ -227,7 +242,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	approvalCallbackFn := awslambda.NewFunction(stack, jsii.String("ApprovalCallback"), &awslambda.FunctionProps{
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Handler:      jsii.String("bootstrap"),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/approvalcallback"), nil),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/approvalcallback"), lambdaAssetOptions()),
 		FunctionName: jsii.String("approval-callback" + suffix),
 		Architecture: lambdaArchitecture(),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),
@@ -276,7 +291,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	sesForwarderFn := awslambda.NewFunction(stack, jsii.String("SESForwarder"), &awslambda.FunctionProps{
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Handler:      jsii.String("bootstrap"),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/sesforwarder"), nil),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/sesforwarder"), lambdaAssetOptions()),
 		FunctionName: jsii.String("ses-forwarder" + suffix),
 		Architecture: lambdaArchitecture(),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),


### PR DESCRIPTION
## Summary
- Use `COMMIT_SHA` as a custom CDK asset hash so every CI deploy produces a new S3 key, forcing CloudFormation to update Lambda code
- Falls back to CDK's default content-hash behavior locally when `COMMIT_SHA` is unset
- Applied to all 10 workflow Lambdas and the mock server Lambda

## Test plan
- [ ] Merge a code change and confirm the deployed Lambda reflects the new code
- [ ] Verify local `cdk synth` still works without `COMMIT_SHA` set