### PR TITLE
feat(infra): add Project and Environment tags to all CDK stacks

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -21,6 +21,14 @@ func main() {
 
 	suffix := os.Getenv("ENV_SUFFIX")
 
+	envName := "prod"
+	if suffix != "" {
+		envName = suffix[1:] // strip leading "-", e.g. "-ci" → "ci"
+	}
+
+	awscdk.Tags_Of(app).Add(jsii.String("Project"), jsii.String("nycares-project-welcomer"), nil)
+	awscdk.Tags_Of(app).Add(jsii.String("Environment"), jsii.String(envName), nil)
+
 	var mockServerUrl *string
 	if os.Getenv("DEPLOY_MOCKSERVER") == "true" {
 		_, url := stack.MockServerStack(app, "NYCaresMockServerStack"+suffix, &awscdk.StackProps{Env: env})


### PR DESCRIPTION
## Summary
- Adds `Project: nycares-project-welcomer` and `Environment: prod/ci` tags at the CDK app level so they propagate automatically to all resources (Lambdas, DynamoDB, S3, SNS, Step Functions, API Gateway)
- Environment value is derived from `ENV_SUFFIX`: empty → `prod`, `-ci` → `ci`

## Related
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)