### PR TITLE
fix(ci): exclude mock server from cleanup environment destroy

### DIFF
--- a/.github/workflows/cleanup-stale-envs.yml
+++ b/.github/workflows/cleanup-stale-envs.yml
@@ -96,7 +96,6 @@ jobs:
           NYCARES_ACCOUNT_PASSWORD: ${{ secrets.NYCARES_ACCOUNT_PASSWORD }}
           NYCARES_AWS_SF_APPROVALSECRET: ${{ secrets.NYCARES_AWS_SF_APPROVALSECRET }}
           GHA_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-          DEPLOY_MOCKSERVER: "true"
         run: |
           cd infra
           go mod download


### PR DESCRIPTION
## Summary
- Removes `DEPLOY_MOCKSERVER: "true"` from the "Destroy CI environment" step in `cleanup-stale-envs.yml` so the mock server stack is not torn down during stale environment cleanup (prod may depend on it).

## Related
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)