### PR TITLE
fix(cdk): make Lambda asset hash unique per function to prevent deduplication

### DIFF
--- a/infra/stack/mockserverstack.go
+++ b/infra/stack/mockserverstack.go
@@ -23,7 +23,7 @@ func MockServerStack(scope constructs.Construct, id string, props *awscdk.StackP
 		Handler:      jsii.String("bootstrap"),
 		Architecture: lambdaArchitecture(),
 		FunctionName: jsii.String("mock-server" + suffix),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/mockserver"), lambdaAssetOptions()),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/mockserver"), lambdaAssetOptions("mockserver")),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),
 		LogGroup:     lambdaLogGroup(stack, "MockServerLogGroup", "/aws/lambda/mock-server"+suffix),
 	})

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -40,11 +40,17 @@ func lambdaArchitecture() awslambda.Architecture {
 // lambdaAssetOptions returns asset options that force a new upload on every CI deploy.
 // When COMMIT_SHA is set (i.e. in GitHub Actions), CDK uses it as a custom hash so
 // CloudFormation always sees a changed S3 key and updates the Lambda code.
+// The name suffix makes each lambda's hash unique so CDK does not deduplicate
+// different binaries onto the same S3 asset.
 // Locally (no COMMIT_SHA), CDK falls back to its default content-hash behavior.
-func lambdaAssetOptions() *awss3assets.AssetOptions {
+func lambdaAssetOptions(name ...string) *awss3assets.AssetOptions {
 	if sha := os.Getenv("COMMIT_SHA"); sha != "" {
+		hash := sha
+		if len(name) > 0 && name[0] != "" {
+			hash = sha + "-" + name[0]
+		}
 		return &awss3assets.AssetOptions{
-			AssetHash:     jsii.String(sha),
+			AssetHash:     jsii.String(hash),
 			AssetHashType: awscdk.AssetHashType_CUSTOM,
 		}
 	}
@@ -182,7 +188,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 			Handler: jsii.String("bootstrap"),
 			Code: awslambda.Code_FromAsset(
 				jsii.String("../lambda-build/"+lowerName),
-				lambdaAssetOptions(),
+				lambdaAssetOptions(lowerName),
 			),
 			FunctionName: jsii.String(kebabName + suffix),
 			Architecture: lambdaArchitecture(),
@@ -234,7 +240,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	approvalCallbackFn := awslambda.NewFunction(stack, jsii.String("ApprovalCallback"), &awslambda.FunctionProps{
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Handler:      jsii.String("bootstrap"),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/approvalcallback"), lambdaAssetOptions()),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/approvalcallback"), lambdaAssetOptions("approvalcallback")),
 		FunctionName: jsii.String("approval-callback" + suffix),
 		Architecture: lambdaArchitecture(),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),
@@ -276,7 +282,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	sesForwarderFn := awslambda.NewFunction(stack, jsii.String("SESForwarder"), &awslambda.FunctionProps{
 		Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
 		Handler:      jsii.String("bootstrap"),
-		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/sesforwarder"), lambdaAssetOptions()),
+		Code:         awslambda.Code_FromAsset(jsii.String("../lambda-build/sesforwarder"), lambdaAssetOptions("sesforwarder")),
 		FunctionName: jsii.String("ses-forwarder" + suffix),
 		Architecture: lambdaArchitecture(),
 		Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),


### PR DESCRIPTION
## Summary
- `lambdaAssetOptions()` returned the same `COMMIT_SHA` hash for every Lambda; CDK deduplicates assets by hash, so all 10 functions ended up sharing the mock server binary (synthesized first). Every Step Functions invocation threw `"unsupported payload format"` because the mock server's `algnhsa` handler rejects non-API-Gateway events.
- Fix: append the lambda name to the hash (`<sha>-<name>`) so each function gets a distinct S3 asset while still forcing a code update on every deploy.

## Root cause trace
1. `MockServerStack` is instantiated before `ProjectNotifierStack` in `infra/main.go`
2. Both stacks called `lambdaAssetOptions()` → same hash → CDK uploaded mock server binary once and reused it for all lambdas
3. Login, FetchProjects, DLQNotifier, etc. were all running `algnhsa.ListenAndServe` → `"unsupported payload format"` on every SFN invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)