### PR TITLE
feat(dto): use Public_Session_Name__c as project name source

### DIFF
--- a/internal/mockserver/routes/mockresponses/schedulemock.go
+++ b/internal/mockserver/routes/mockresponses/schedulemock.go
@@ -35,6 +35,7 @@ func MockUpcomingResponse(projects []ProjectConfig) []dto.UpcomingResponse {
 	for _, p := range projects {
 		sessions = append(sessions, dto.UpcomingSession{
 			Name:               p.Name,
+			PublicSessionName:  p.Name,
 			FamilyFriendlyRole: nil,
 			SessionID:          p.Id,
 			Status:             "Published",

--- a/internal/platform/http/dto/upcoming.go
+++ b/internal/platform/http/dto/upcoming.go
@@ -19,6 +19,7 @@ type UserFlagged struct {
 
 type UpcomingSession struct {
 	Name               string  `json:"Name"`
+	PublicSessionName  string  `json:"Public_Session_Name__c"`
 	FamilyFriendlyRole *string `json:"Family_Friendly_Role__c"`
 	SessionID          string  `json:"Session__c"`
 	Status             string  `json:"Status__c"`
@@ -56,7 +57,7 @@ func (ur UpcomingResponse) ToDomainProjects() ([]domain.Project, error) {
 			return nil, fmt.Errorf("could not parse date from upcoming projects response")
 		}
 		projects = append(projects, domain.Project{
-			Name:      s.Name,
+			Name:      s.PublicSessionName,
 			Date:      projectDate,
 			Id:        s.SessionID,
 			ChannelId: s.AWSChimeChannelID,


### PR DESCRIPTION
## Summary

- Adds `Public_Session_Name__c` field to `UpcomingSession` DTO
- `ToDomainProjects()` now reads `PublicSessionName` instead of `Name` for `domain.Project.Name`
- Mock server populates `PublicSessionName` from `ProjectConfig.Name` to keep integration tests consistent

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)