### PR TITLE
fix: add retry logic to Login and FetchProjects workflow steps

### DIFF
--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -11,6 +11,14 @@
       },
       "ResultPath": "$",
       "Next": "FetchProjects",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2
+        }
+      ],
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -33,6 +41,14 @@
       "InputPath": "$",
       "ResultPath": "$.projects",
       "Next": "ProcessEachProject",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2
+        }
+      ],
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],


### PR DESCRIPTION
## Summary
- Add `Retry` block to `Login` and `FetchProjects` Step Functions states to recover from transient network errors (e.g. broken pipe)
- Retry config matches existing DLQNotifier pattern: 2 max attempts, 5s initial interval, 2x backoff

## Test plan
- [ ] Trigger a workflow execution and confirm it succeeds end-to-end
- [ ] Simulate a transient failure on `Login` or `FetchProjects` and confirm the step retries before failing