### PR TITLE
fix: add dummy SES env vars so ses-forwarder initializes cleanly locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,6 +97,8 @@ services:
       - NYCARES_AWS_SF_CALLBACKENDPOINT=http://localhost:4566
       - NYCARES_AWS_SF_APPROVALSECRET=test-secret
       - NYCARES_MOCK_GENERATETHANKYOU=true
+      - NYCARES_AWS_SES_SENDER=noreply@localhost
+      - NYCARES_AWS_SES_RECIPIENT=dev@localhost
       - NYCARES_LAMBDA_ARCH=${LAMBDA_GOARCH:-arm64}
     command: >
       sh -c "go mod download &&


### PR DESCRIPTION
## Summary
- Add `NYCARES_AWS_SES_SENDER` and `NYCARES_AWS_SES_RECIPIENT` dummy values to `docker-compose.yaml` so `ses-forwarder` passes config validation on startup
- Without these, the lambda panicked before init, causing LocalStack to spin up a new container on every SNS notification

## Test plan
- [ ] Run `docker compose up --build` locally and trigger a workflow — confirm ses-forwarder no longer spawns repeated containers
- [ ] Integration tests pass (9/9 scenarios green)