### PR TITLE
feat(ci): use real Bedrock for GenerateThankYouMessage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
           NYCARES_ACCOUNT_USERNAME: ${{ secrets.NYCARES_ACCOUNT_USERNAME }}
           NYCARES_ACCOUNT_PASSWORD: ${{ secrets.NYCARES_ACCOUNT_PASSWORD }}
           NYCARES_AWS_SF_APPROVALSECRET: ${{ secrets.NYCARES_AWS_SF_APPROVALSECRET }}
-          NYCARES_MOCK_GENERATETHANKYOU: "true"
           GHA_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         run: |
           cd infra

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -186,6 +186,11 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		lowerName := strings.ToLower(name)
 		kebabName := strcase.ToKebab(name)
 
+		timeout := jsii.Number(30)
+		if name == "GenerateThankYouMessage" {
+			timeout = jsii.Number(60)
+		}
+
 		fn := awslambda.NewFunction(stack, jsii.String(name), &awslambda.FunctionProps{
 			Runtime: awslambda.Runtime_PROVIDED_AL2023(),
 			Handler: jsii.String("bootstrap"),
@@ -195,7 +200,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 			),
 			FunctionName: jsii.String(kebabName + suffix),
 			Architecture: lambdaArchitecture(),
-			Timeout:      awscdk.Duration_Seconds(jsii.Number(30)),
+			Timeout:      awscdk.Duration_Seconds(timeout),
 			Environment:  sharedEnv,
 			LogGroup:     lambdaLogGroup(stack, name+"LogGroup", "/aws/lambda/"+kebabName+suffix),
 		})
@@ -234,10 +239,10 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	bucket.GrantRead(lambdaFns["RequestApprovalToSend"], nil)
 	bucket.GrantRead(lambdaFns["GenerateThankYouMessage"], nil)
 
-	// GenerateThankYouMessage needs Bedrock InvokeModel
+	// GenerateThankYouMessage needs Bedrock InvokeModel (wildcard covers foundation models and inference profiles)
 	lambdaFns["GenerateThankYouMessage"].AddToRolePolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
 		Actions:   jsii.Strings("bedrock:InvokeModel"),
-		Resources: jsii.Strings(fmt.Sprintf("arn:aws:bedrock:%s::foundation-model/anthropic.claude-3-5-haiku-20241022", *stack.Region())),
+		Resources: jsii.Strings("*"),
 	}))
 
 	// SNS publish for notification lambdas

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -162,6 +162,14 @@ func (tc *testClients) pollForTaskToken(executionArn string) (string, error) {
 					return token, nil
 				}
 			}
+			// Execution failed before a task token was ever scheduled;
+			// scan remaining events for the actual Lambda error.
+			if event.Type == sfntypes.HistoryEventTypeExecutionFailed ||
+				event.Type == sfntypes.HistoryEventTypeExecutionAborted ||
+				event.Type == sfntypes.HistoryEventTypeExecutionTimedOut {
+				lambdaErr := extractLambdaFailure(result.Events)
+				return "", fmt.Errorf("execution failed before task token (lambda error: %s)", lambdaErr)
+			}
 		}
 
 		time.Sleep(pollInterval)
@@ -185,6 +193,19 @@ func extractTaskToken(params string) string {
 	}
 
 	return ""
+}
+
+// extractLambdaFailure scans execution history events (reverse-ordered) for the
+// most recent LambdaFunctionFailed event and returns its error + cause string.
+func extractLambdaFailure(events []sfntypes.HistoryEvent) string {
+	for _, e := range events {
+		if e.Type == sfntypes.HistoryEventTypeLambdaFunctionFailed && e.LambdaFunctionFailedEventDetails != nil {
+			errStr := aws.ToString(e.LambdaFunctionFailedEventDetails.Error)
+			cause := aws.ToString(e.LambdaFunctionFailedEventDetails.Cause)
+			return fmt.Sprintf("error=%s cause=%s", errStr, cause)
+		}
+	}
+	return "unknown (no LambdaFunctionFailed event found)"
 }
 
 func (tc *testClients) approveTask(taskToken string) error {

--- a/internal/config/timeout.go
+++ b/internal/config/timeout.go
@@ -11,4 +11,8 @@ const (
 	// HTTP calls (login, fetch projects, send messages).
 	// Set below the Lambda function timeout (30s) to allow graceful error propagation.
 	HTTPHandlerTimeout = 25 * time.Second
+
+	// AIHandlerTimeout is the timeout for handlers that call AI generation
+	// services (e.g. Bedrock). Set below the Lambda function timeout (60s).
+	AIHandlerTimeout = 55 * time.Second
 )

--- a/internal/platform/bedrock/bedrockservice.go
+++ b/internal/platform/bedrock/bedrockservice.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
 
-const ModelID = "anthropic.claude-3-5-haiku-20241022"
+const ModelID = "us.amazon.nova-lite-v1:0"
 
 type GenerationService interface {
 	GenerateThankYouMessage(ctx context.Context, writingSample, projectName string) (string, error)

--- a/lambda/generatethankyoumessage/handler.go
+++ b/lambda/generatethankyoumessage/handler.go
@@ -21,7 +21,7 @@ func NewGenerateThankYouMessageHandler(u *gtm.GenerateThankYouMessageUseCase, cf
 func (h *GenerateThankYouMessageHandler) Handle(ctx context.Context, input models.GenerateThankYouMessageInput) (models.GenerateThankYouMessageOutput, error) {
 	slog.Info("generatethankyoumessage handler invoked", "executionId", input.ExecutionId, "project", input.ExistingProjectNotification.Name)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := context.WithTimeout(ctx, config.AIHandlerTimeout)
 	defer cancel()
 
 	generatedContent, err := h.usecase.Execute(ctx, input.ExistingProjectNotification.Name)


### PR DESCRIPTION
## Summary
- Remove `NYCARES_MOCK_GENERATETHANKYOU` from CI so `GenerateThankYouMessage` calls real Bedrock instead of the mock passthrough
- Use Amazon Nova Lite (`us.amazon.nova-lite-v1:0`) — Anthropic models require an account-level use case form; Nova Lite is immediately available and capable enough for short thank-you messages
- Give `GenerateThankYouMessage` Lambda a 60s timeout and a 55s handler context to accommodate Bedrock latency
- Widen IAM to `bedrock:InvokeModel` on `*` so cross-region inference profile ARNs are covered
- Fix `pollForTaskToken` to bail immediately when the SFN execution fails and surface the actual `LambdaFunctionFailed` error from the execution history

## Test plan
- [ ] CI passes — `ThankYou_message_is_sent_on_the_day_of_the_project` scenario succeeds with a real Bedrock-generated message
- [ ] Confirm the generated thank-you message appears in the SNS approval notification (not a hardcoded template)
