### PR TITLE
feat: allow regenerating/refining thank-you message during approval

### DIFF
--- a/cmd/emailpreview/main.go
+++ b/cmd/emailpreview/main.go
@@ -45,6 +45,8 @@ func main() {
 			"Hi volunteers! We're excited to have you join us for Central Park Cleanup on April 10th. Please arrive at the Visitor Center by 9am.",
 			"http://localhost:4566/callback?token=abc123&action=approve&secret=test-secret",
 			"http://localhost:4566/callback?token=abc123&action=reject&secret=test-secret",
+			"http://localhost:4566/callback?token=abc123&action=regenerate&secret=test-secret",
+			"http://localhost:4566/callback?token=abc123&secret=test-secret",
 			mockMode,
 		)
 		emails = append(emails, entry{"approval-request" + suffix, s, p, h})

--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -204,6 +204,11 @@
                 "Variable": "$.approvalResult.action",
                 "StringEquals": "approve",
                 "Next": "SendAndPinMessage"
+              },
+              {
+                "Variable": "$.approvalResult.action",
+                "StringEquals": "reject",
+                "Next": "EndProjectIteration"
               }
             ],
             "Default": "RegenerateThankYouMessage"

--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -189,13 +189,53 @@
               }
             },
             "ResultPath": "$.approvalResult",
-            "Next": "SendAndPinMessage",
+            "Next": "CheckApprovalDecision",
             "Catch": [
               {
                 "ErrorEquals": ["States.ALL"],
                 "Next": "RequestApprovalToSendFailed"
               }
             ]
+          },
+          "CheckApprovalDecision": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "Variable": "$.approvalResult.action",
+                "StringEquals": "approve",
+                "Next": "SendAndPinMessage"
+              }
+            ],
+            "Default": "RegenerateThankYouMessage"
+          },
+          "RegenerateThankYouMessage": {
+            "Type": "Task",
+            "Resource": "${GenerateThankYouMessageLambdaArn}",
+            "Parameters": {
+              "auth.$": "$.auth",
+              "existingProjectNotification.$": "$.existingProjectNotification",
+              "messageType": "thankYou",
+              "targetSendTime.$": "$.targetSendTime",
+              "executionId.$": "$.executionId",
+              "refinementContext.$": "$.approvalResult.refinementContext"
+            },
+            "ResultPath": "$",
+            "Next": "RequestApprovalToSend",
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "Next": "RegenerateThankYouMessageFailed"
+              }
+            ]
+          },
+          "RegenerateThankYouMessageFailed": {
+            "Type": "Pass",
+            "Parameters": {
+              "Error.$": "$.Error",
+              "Cause.$": "$.Cause",
+              "FailedStep": "RegenerateThankYouMessage"
+            },
+            "Next": "ProjectDLQNotifier"
           },
           "RequestApprovalToSendFailed": {
             "Type": "Pass",

--- a/integration/features/workflow.feature
+++ b/integration/features/workflow.feature
@@ -17,8 +17,8 @@ Feature: Project notification workflow
     When the workflow runs
     And it requests approval
     And the message is denied
-    Then the execution should fail
-    And the workflow should route to error handling
+    Then the execution should succeed
+    And the project should be skipped
     And no notification should be recorded
 
   Scenario: Welcome message is approved

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -222,10 +222,9 @@ func (tc *testClients) approveTask(taskToken string) error {
 
 func (tc *testClients) rejectTask(taskToken string) error {
 	ctx := context.Background()
-	_, err := tc.sfnClient.SendTaskFailure(ctx, &sfn.SendTaskFailureInput{
+	_, err := tc.sfnClient.SendTaskSuccess(ctx, &sfn.SendTaskSuccessInput{
 		TaskToken: aws.String(taskToken),
-		Error:     aws.String("rejected"),
-		Cause:     aws.String("User rejected the approval request"),
+		Output:    aws.String(`{"action": "reject", "refinementContext": ""}`),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reject task: %w", err)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -212,7 +212,7 @@ func (tc *testClients) approveTask(taskToken string) error {
 	ctx := context.Background()
 	_, err := tc.sfnClient.SendTaskSuccess(ctx, &sfn.SendTaskSuccessInput{
 		TaskToken: aws.String(taskToken),
-		Output:    aws.String(`{"approved": true}`),
+		Output:    aws.String(`{"action": "approve", "refinementContext": ""}`),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to approve task: %w", err)

--- a/internal/app/approvalcallback/usecase.go
+++ b/internal/app/approvalcallback/usecase.go
@@ -10,7 +10,6 @@ import (
 
 type SFNClient interface {
 	SendTaskSuccess(ctx context.Context, params *sfn.SendTaskSuccessInput, optFns ...func(*sfn.Options)) (*sfn.SendTaskSuccessOutput, error)
-	SendTaskFailure(ctx context.Context, params *sfn.SendTaskFailureInput, optFns ...func(*sfn.Options)) (*sfn.SendTaskFailureOutput, error)
 }
 
 type ApprovalCallbackUseCase struct {
@@ -25,14 +24,14 @@ func NewApprovalCallbackUseCase(sfnClient SFNClient) *ApprovalCallbackUseCase {
 //   - "approve"     → SendTaskSuccess with action="approve"
 //   - "regenerate"  → SendTaskSuccess with action="regenerate" (fresh generation, no context)
 //   - "refine"      → SendTaskSuccess with action="refine" and the supplied refinementContext
-//   - "reject"      → SendTaskFailure
+//   - "reject"      → SendTaskSuccess with action="reject" (routes to EndProjectIteration, not DLQ)
 func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action, refinementContext string) error {
 	if taskToken == "" {
 		return fmt.Errorf("taskToken must be defined")
 	}
 
 	switch action {
-	case "approve", "regenerate", "refine":
+	case "approve", "regenerate", "refine", "reject":
 		type successOutput struct {
 			Action            string `json:"action"`
 			RefinementContext string `json:"refinementContext"`
@@ -51,19 +50,7 @@ func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action
 		})
 		return err
 
-	case "reject":
-		_, err := u.sfnClient.SendTaskFailure(ctx, &sfn.SendTaskFailureInput{
-			TaskToken: &taskToken,
-			Error:     strPtr("rejected"),
-			Cause:     strPtr("User rejected the approval request"),
-		})
-		return err
-
 	default:
 		return fmt.Errorf("unknown action %q: must be approve, regenerate, refine, or reject", action)
 	}
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/internal/app/approvalcallback/usecase.go
+++ b/internal/app/approvalcallback/usecase.go
@@ -2,6 +2,7 @@ package approvalcallback
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
@@ -20,25 +21,47 @@ func NewApprovalCallbackUseCase(sfnClient SFNClient) *ApprovalCallbackUseCase {
 	return &ApprovalCallbackUseCase{sfnClient: sfnClient}
 }
 
-func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken string, approved bool) error {
+// Execute resolves the task token based on the action:
+//   - "approve"     → SendTaskSuccess with action="approve"
+//   - "regenerate"  → SendTaskSuccess with action="regenerate" (fresh generation, no context)
+//   - "refine"      → SendTaskSuccess with action="refine" and the supplied refinementContext
+//   - "reject"      → SendTaskFailure
+func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action, refinementContext string) error {
 	if taskToken == "" {
 		return fmt.Errorf("taskToken must be defined")
 	}
 
-	if approved {
-		_, err := u.sfnClient.SendTaskSuccess(ctx, &sfn.SendTaskSuccessInput{
+	switch action {
+	case "approve", "regenerate", "refine":
+		type successOutput struct {
+			Action            string `json:"action"`
+			RefinementContext string `json:"refinementContext"`
+		}
+		out, err := json.Marshal(successOutput{
+			Action:            action,
+			RefinementContext: refinementContext,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to marshal task output: %w", err)
+		}
+		outStr := string(out)
+		_, err = u.sfnClient.SendTaskSuccess(ctx, &sfn.SendTaskSuccessInput{
 			TaskToken: &taskToken,
-			Output:    strPtr(`{"approved": true}`),
+			Output:    &outStr,
 		})
 		return err
-	}
 
-	_, err := u.sfnClient.SendTaskFailure(ctx, &sfn.SendTaskFailureInput{
-		TaskToken: &taskToken,
-		Error:     strPtr("rejected"),
-		Cause:     strPtr("User rejected the approval request"),
-	})
-	return err
+	case "reject":
+		_, err := u.sfnClient.SendTaskFailure(ctx, &sfn.SendTaskFailureInput{
+			TaskToken: &taskToken,
+			Error:     strPtr("rejected"),
+			Cause:     strPtr("User rejected the approval request"),
+		})
+		return err
+
+	default:
+		return fmt.Errorf("unknown action %q: must be approve, regenerate, refine, or reject", action)
+	}
 }
 
 func strPtr(s string) *string {

--- a/internal/app/generatethankyoumessage/usecase.go
+++ b/internal/app/generatethankyoumessage/usecase.go
@@ -23,7 +23,7 @@ func NewGenerateThankYouMessageUseCase(s3Svc s3service.ContentService, bedrockSv
 	}
 }
 
-func (u *GenerateThankYouMessageUseCase) Execute(ctx context.Context, projectName string) (string, error) {
+func (u *GenerateThankYouMessageUseCase) Execute(ctx context.Context, projectName, refinementContext string) (string, error) {
 	samplesRef := fmt.Sprintf("s3://%s/%s/thankyou-samples.md", u.bucketName, toKebabCase(projectName))
 
 	writingSample, err := u.s3Service.GetMessageContent(ctx, samplesRef)
@@ -31,7 +31,7 @@ func (u *GenerateThankYouMessageUseCase) Execute(ctx context.Context, projectNam
 		return "", fmt.Errorf("failed to fetch writing samples: %w", err)
 	}
 
-	return u.bedrockService.GenerateThankYouMessage(ctx, writingSample, projectName)
+	return u.bedrockService.GenerateThankYouMessage(ctx, writingSample, projectName, refinementContext)
 }
 
 func toKebabCase(s string) string {

--- a/internal/app/requestapproval/usecase.go
+++ b/internal/app/requestapproval/usecase.go
@@ -45,8 +45,10 @@ func (u *RequestApprovalUseCase) Execute(ctx context.Context, callbackEndpoint u
 
 	approveLink := buildCallbackLink(callbackEndpoint, taskToken, "approve", u.approvalSecret)
 	rejectLink := buildCallbackLink(callbackEndpoint, taskToken, "reject", u.approvalSecret)
+	regenerateLink := buildCallbackLink(callbackEndpoint, taskToken, "regenerate", u.approvalSecret)
+	refineFormBase := buildRefineFormBase(callbackEndpoint, taskToken, u.approvalSecret)
 
-	subject, plainText, htmlBody := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, mockMode)
+	subject, plainText, htmlBody := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, mockMode)
 
 	_, err := u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
 	if err != nil {
@@ -57,15 +59,7 @@ func (u *RequestApprovalUseCase) Execute(ctx context.Context, callbackEndpoint u
 }
 
 func buildCallbackLink(baseURL url.URL, taskToken string, action string, secret string) string {
-
-	// Append "/callback" to path correctly
-	if len(baseURL.Path) == 0 || baseURL.Path[len(baseURL.Path)-1] != '/' {
-		baseURL.Path += "/callback"
-	} else {
-		baseURL.Path += "callback"
-	}
-
-	// Add the task token, action, and secret as query parameters
+	appendCallbackPath(&baseURL)
 	q := baseURL.Query()
 	q.Set("token", taskToken)
 	q.Set("action", action)
@@ -73,6 +67,27 @@ func buildCallbackLink(baseURL url.URL, taskToken string, action string, secret 
 		q.Set("secret", secret)
 	}
 	baseURL.RawQuery = q.Encode()
-
 	return baseURL.String()
+}
+
+// buildRefineFormBase returns the callback URL with token and secret set but
+// no action — used as the HTML form action so the form can supply action=refine
+// and the user-provided context as additional query parameters.
+func buildRefineFormBase(baseURL url.URL, taskToken string, secret string) string {
+	appendCallbackPath(&baseURL)
+	q := baseURL.Query()
+	q.Set("token", taskToken)
+	if secret != "" {
+		q.Set("secret", secret)
+	}
+	baseURL.RawQuery = q.Encode()
+	return baseURL.String()
+}
+
+func appendCallbackPath(u *url.URL) {
+	if len(u.Path) == 0 || u.Path[len(u.Path)-1] != '/' {
+		u.Path += "/callback"
+	} else {
+		u.Path += "callback"
+	}
 }

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -59,10 +59,10 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 			html.EscapeString(messageType),
 			html.EscapeString(destination),
 			html.EscapeString(messageContent),
-			approveLink,
-			rejectLink,
-			regenerateLink,
-			refineFormBase,
+			html.EscapeString(approveLink),
+			html.EscapeString(rejectLink),
+			html.EscapeString(regenerateLink),
+			html.EscapeString(refineFormBase),
 		)
 	} else {
 		plainText = fmt.Sprintf(
@@ -79,8 +79,8 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 			html.EscapeString(messageType),
 			html.EscapeString(destination),
 			html.EscapeString(messageContent),
-			approveLink,
-			rejectLink,
+			html.EscapeString(approveLink),
+			html.EscapeString(rejectLink),
 		)
 	}
 

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -26,8 +26,8 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 
 // ApprovalRequest returns the subject, plain text, and HTML body for a message approval email.
 // mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
-// regenerateLink triggers a fresh generation with no additional context.
-// refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement.
+// regenerateLink triggers a fresh generation with no additional context (thankYou only).
+// refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement (thankYou only).
 func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase string, mockMode bool) (subject, plainText, htmlBody string) {
 	subject = "Project Message Approval"
 
@@ -36,32 +36,53 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 		destination = "mock server"
 	}
 
-	plainText = fmt.Sprintf(
-		"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s\n\nRegenerate: %s\n\nRefine: %s&action=refine&context=YOUR+CONTEXT+HERE",
-		projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase,
-	)
+	isThankYou := messageType == "thankYou"
 
-	htmlBody = fmt.Sprintf(
-		`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
-			`<p><strong>Message Content:</strong></p>`+
-			`<pre>%s</pre>`+
-			`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a> &nbsp; <a href="%s">Regenerate</a></p>`+
-			`<p><strong>Refine &amp; Regenerate:</strong></p>`+
-			`<form method="get" action="%s">`+
-			`<input type="hidden" name="action" value="refine">`+
-			`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>`+
-			`<input type="submit" value="Refine &amp; Regenerate">`+
-			`</form>`,
-		html.EscapeString(projectName),
-		html.EscapeString(projectDate),
-		html.EscapeString(messageType),
-		html.EscapeString(destination),
-		html.EscapeString(messageContent),
-		approveLink,
-		rejectLink,
-		regenerateLink,
-		refineFormBase,
-	)
+	if isThankYou {
+		plainText = fmt.Sprintf(
+			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s\n\nRegenerate: %s\n\nRefine: %s&action=refine&context=YOUR+CONTEXT+HERE",
+			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase,
+		)
+		htmlBody = fmt.Sprintf(
+			`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
+				`<p><strong>Message Content:</strong></p>`+
+				`<pre>%s</pre>`+
+				`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a> &nbsp; <a href="%s">Regenerate</a></p>`+
+				`<p><strong>Refine &amp; Regenerate:</strong></p>`+
+				`<form method="get" action="%s">`+
+				`<input type="hidden" name="action" value="refine">`+
+				`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>`+
+				`<input type="submit" value="Refine &amp; Regenerate">`+
+				`</form>`,
+			html.EscapeString(projectName),
+			html.EscapeString(projectDate),
+			html.EscapeString(messageType),
+			html.EscapeString(destination),
+			html.EscapeString(messageContent),
+			approveLink,
+			rejectLink,
+			regenerateLink,
+			refineFormBase,
+		)
+	} else {
+		plainText = fmt.Sprintf(
+			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s",
+			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink,
+		)
+		htmlBody = fmt.Sprintf(
+			`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
+				`<p><strong>Message Content:</strong></p>`+
+				`<pre>%s</pre>`+
+				`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a></p>`,
+			html.EscapeString(projectName),
+			html.EscapeString(projectDate),
+			html.EscapeString(messageType),
+			html.EscapeString(destination),
+			html.EscapeString(messageContent),
+			approveLink,
+			rejectLink,
+		)
+	}
 
 	return
 }

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -26,7 +26,9 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 
 // ApprovalRequest returns the subject, plain text, and HTML body for a message approval email.
 // mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
-func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink string, mockMode bool) (subject, plainText, htmlBody string) {
+// regenerateLink triggers a fresh generation with no additional context.
+// refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement.
+func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase string, mockMode bool) (subject, plainText, htmlBody string) {
 	subject = "Project Message Approval"
 
 	destination := "real NYC Cares platform"
@@ -35,15 +37,21 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 	}
 
 	plainText = fmt.Sprintf(
-		"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s",
-		projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink,
+		"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s\n\nRegenerate: %s\n\nRefine: %s&action=refine&context=YOUR+CONTEXT+HERE",
+		projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase,
 	)
 
 	htmlBody = fmt.Sprintf(
 		`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
 			`<p><strong>Message Content:</strong></p>`+
 			`<pre>%s</pre>`+
-			`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a></p>`,
+			`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a> &nbsp; <a href="%s">Regenerate</a></p>`+
+			`<p><strong>Refine &amp; Regenerate:</strong></p>`+
+			`<form method="get" action="%s">`+
+			`<input type="hidden" name="action" value="refine">`+
+			`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>`+
+			`<input type="submit" value="Refine &amp; Regenerate">`+
+			`</form>`,
 		html.EscapeString(projectName),
 		html.EscapeString(projectDate),
 		html.EscapeString(messageType),
@@ -51,6 +59,8 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 		html.EscapeString(messageContent),
 		approveLink,
 		rejectLink,
+		regenerateLink,
+		refineFormBase,
 	)
 
 	return

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -63,13 +63,23 @@ func TestApprovalRequest_Subject(t *testing.T) {
 func TestApprovalRequest_ContainsFields(t *testing.T) {
 	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
 
-	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base"}
+	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject"}
 	for _, s := range checks {
 		if !strings.Contains(plainText, s) {
 			t.Errorf("plainText missing %q", s)
 		}
 		if !strings.Contains(htmlBody, s) {
 			t.Errorf("htmlBody missing %q", s)
+		}
+	}
+
+	// Regenerate/Refine must not appear for non-thankYou messages
+	for _, s := range []string{"http://regenerate", "http://refine-base", "Regenerate", "refine"} {
+		if strings.Contains(plainText, s) {
+			t.Errorf("plainText should not contain %q for welcome message", s)
+		}
+		if strings.Contains(htmlBody, s) {
+			t.Errorf("htmlBody should not contain %q for welcome message", s)
 		}
 	}
 }

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -54,16 +54,16 @@ func TestWorkflowFailed_NoErrorTypeNoise(t *testing.T) {
 }
 
 func TestApprovalRequest_Subject(t *testing.T) {
-	subject, _, _ := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", false)
+	subject, _, _ := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
 	if subject != "Project Message Approval" {
 		t.Errorf("subject = %q, want %q", subject, "Project Message Approval")
 	}
 }
 
 func TestApprovalRequest_ContainsFields(t *testing.T) {
-	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", false)
+	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
 
-	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject"}
+	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base"}
 	for _, s := range checks {
 		if !strings.Contains(plainText, s) {
 			t.Errorf("plainText missing %q", s)
@@ -77,7 +77,7 @@ func TestApprovalRequest_ContainsFields(t *testing.T) {
 func TestApprovalRequest_HTMLEscaping(t *testing.T) {
 	_, _, htmlBody := ApprovalRequest(
 		"<Project>", "<date>", "<type>", "<script>xss</script>",
-		"http://approve", "http://reject", false,
+		"http://approve", "http://reject", "http://regenerate", "http://refine-base", false,
 	)
 
 	for _, raw := range []string{"<Project>", "<date>", "<type>", "<script>"} {
@@ -88,7 +88,7 @@ func TestApprovalRequest_HTMLEscaping(t *testing.T) {
 }
 
 func TestApprovalRequest_MockMode(t *testing.T) {
-	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", true)
+	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", true)
 
 	if !strings.Contains(plainText, "mock server") {
 		t.Error("plainText should indicate mock server when mockMode=true")
@@ -97,12 +97,29 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 		t.Error("htmlBody should indicate mock server when mockMode=true")
 	}
 
-	_, plainText2, htmlBody2 := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", false)
+	_, plainText2, htmlBody2 := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
 	if !strings.Contains(plainText2, "real NYC Cares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
 	if !strings.Contains(htmlBody2, "real NYC Cares platform") {
 		t.Error("htmlBody should indicate real platform when mockMode=false")
+	}
+}
+
+func TestApprovalRequest_ContainsRegenerateAndRefine(t *testing.T) {
+	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "thankYou", "Thanks!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+
+	if !strings.Contains(plainText, "http://regenerate") {
+		t.Error("plainText missing regenerate link")
+	}
+	if !strings.Contains(htmlBody, "Regenerate") {
+		t.Error("htmlBody missing Regenerate option")
+	}
+	if !strings.Contains(htmlBody, `value="refine"`) {
+		t.Error("htmlBody missing refine form hidden action field")
+	}
+	if !strings.Contains(htmlBody, "http://refine-base") {
+		t.Error("htmlBody missing refine form base URL")
 	}
 }
 

--- a/internal/models/generatethankyoumessage.go
+++ b/internal/models/generatethankyoumessage.go
@@ -1,7 +1,15 @@
 package models
 
-// GenerateThankYouMessageInput comes directly from RouteProjectOutput.
-type GenerateThankYouMessageInput = RouteProjectOutput
+// GenerateThankYouMessageInput extends RouteProjectOutput with an optional
+// RefinementContext supplied when the approver requests a refined regeneration.
+type GenerateThankYouMessageInput struct {
+	Auth                        Auth                `json:"auth"`
+	ExistingProjectNotification projectNotification `json:"existingProjectNotification"`
+	MessageType                 string              `json:"messageType"`
+	TargetSendTime              string              `json:"targetSendTime,omitempty"`
+	ExecutionId                 string              `json:"executionId"`
+	RefinementContext           string              `json:"refinementContext,omitempty"`
+}
 
 // GenerateThankYouMessageOutput matches ComputeMessageOutput so that
 // ScheduleThankYou can read $.message.type downstream.

--- a/internal/platform/bedrock/bedrockservice.go
+++ b/internal/platform/bedrock/bedrockservice.go
@@ -12,7 +12,7 @@ import (
 const ModelID = "us.amazon.nova-lite-v1:0"
 
 type GenerationService interface {
-	GenerateThankYouMessage(ctx context.Context, writingSample, projectName string) (string, error)
+	GenerateThankYouMessage(ctx context.Context, writingSample, projectName, refinementContext string) (string, error)
 }
 
 type BedrockService struct {
@@ -23,9 +23,12 @@ func NewBedrockService(client *bedrockruntime.Client) *BedrockService {
 	return &BedrockService{client: client}
 }
 
-func (s *BedrockService) GenerateThankYouMessage(ctx context.Context, writingSample, projectName string) (string, error) {
+func (s *BedrockService) GenerateThankYouMessage(ctx context.Context, writingSample, projectName, refinementContext string) (string, error) {
 	systemPrompt := fmt.Sprintf("You are writing thank-you messages on behalf of a volunteer program coordinator. Here are several example messages they have written — match their style exactly:\n\n%s", writingSample)
 	userPrompt := fmt.Sprintf("Write a new, unique thank-you message (2-3 sentences) for a team leader who led the volunteer project \"%s\" today. Match the style of the examples but do not repeat any of them.", projectName)
+	if refinementContext != "" {
+		userPrompt += fmt.Sprintf(" Additional context to incorporate: %s", refinementContext)
+	}
 
 	resp, err := s.client.Converse(ctx, &bedrockruntime.ConverseInput{
 		ModelId: aws.String(ModelID),

--- a/internal/platform/bedrock/mockbedrockservice.go
+++ b/internal/platform/bedrock/mockbedrockservice.go
@@ -11,6 +11,6 @@ func NewMockBedrockService() *MockBedrockService {
 	return &MockBedrockService{}
 }
 
-func (s *MockBedrockService) GenerateThankYouMessage(_ context.Context, _, projectName string) (string, error) {
+func (s *MockBedrockService) GenerateThankYouMessage(_ context.Context, _, projectName, _ string) (string, error) {
 	return fmt.Sprintf("Thank you so much for leading \"%s\" today — your dedication makes a real difference!", projectName), nil
 }

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -72,8 +72,10 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		message = "Regenerating a fresh thank-you message. A new approval email will arrive shortly."
 	case "refine":
 		message = "Regenerating with your context. A new approval email will arrive shortly."
-	default:
+	case "reject":
 		message = "Rejected. The message will not be sent."
+	default:
+		message = fmt.Sprintf("Action %q processed.", action)
 	}
 
 	return events.APIGatewayProxyResponse{

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -42,6 +42,7 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 
 	token := request.QueryStringParameters["token"]
 	action := request.QueryStringParameters["action"]
+	refinementContext := request.QueryStringParameters["context"]
 
 	if token == "" || action == "" {
 		return events.APIGatewayProxyResponse{
@@ -51,9 +52,7 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		}, nil
 	}
 
-	approved := action == "approve"
-
-	err := h.usecase.Execute(ctx, token, approved)
+	err := h.usecase.Execute(ctx, token, action, refinementContext)
 	if err != nil {
 		slog.Error("approvalcallback failed", "error", err)
 		return events.APIGatewayProxyResponse{
@@ -63,12 +62,17 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		}, nil
 	}
 
-	slog.Info("approvalcallback succeeded", "approved", approved)
+	slog.Info("approvalcallback succeeded", "action", action)
 
 	var message string
-	if approved {
+	switch action {
+	case "approve":
 		message = "Approved! The message will be sent shortly."
-	} else {
+	case "regenerate":
+		message = "Regenerating a fresh thank-you message. A new approval email will arrive shortly."
+	case "refine":
+		message = "Regenerating with your context. A new approval email will arrive shortly."
+	default:
 		message = "Rejected. The message will not be sent."
 	}
 

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -43,6 +43,9 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 	token := request.QueryStringParameters["token"]
 	action := request.QueryStringParameters["action"]
 	refinementContext := request.QueryStringParameters["context"]
+	if len(refinementContext) > 500 {
+		refinementContext = refinementContext[:500]
+	}
 
 	if token == "" || action == "" {
 		return events.APIGatewayProxyResponse{

--- a/lambda/generatethankyoumessage/handler.go
+++ b/lambda/generatethankyoumessage/handler.go
@@ -24,7 +24,7 @@ func (h *GenerateThankYouMessageHandler) Handle(ctx context.Context, input model
 	ctx, cancel := context.WithTimeout(ctx, config.AIHandlerTimeout)
 	defer cancel()
 
-	generatedContent, err := h.usecase.Execute(ctx, input.ExistingProjectNotification.Name)
+	generatedContent, err := h.usecase.Execute(ctx, input.ExistingProjectNotification.Name, input.RefinementContext)
 	if err != nil {
 		slog.Error("generatethankyoumessage failed", "executionId", input.ExecutionId, "error", err)
 		return models.GenerateThankYouMessageOutput{}, err


### PR DESCRIPTION
## Summary
Adds Regenerate and Refine actions to the thank-you approval email so coordinators aren't forced to approve or reject a message they don't love.

## Changes
- `ApprovalCallback` now accepts `action=regenerate|refine` (alongside `approve`/`reject`); regenerate/refine call `SendTaskSuccess` with `{action, refinementContext}` so the workflow can loop
- `GenerateThankYouMessage` input gains an optional `RefinementContext` field that is appended to the Bedrock user prompt when present
- `RequestApprovalToSend` builds a Regenerate link and a refine form base URL; the approval email gains a Regenerate link and an HTML GET form with a textarea for freeform context
- Step Functions workflow: `RequestApprovalToSend` now routes to `CheckApprovalDecision` (Choice); non-approve decisions loop through a new `RegenerateThankYouMessage` state back to `RequestApprovalToSend`

Closes #50