### PR TITLE
fix(routeproject): include exact 7-day boundary in welcome window

### DIFF
--- a/internal/app/routeproject/usecase.go
+++ b/internal/app/routeproject/usecase.go
@@ -141,7 +141,7 @@ const (
 
 func shouldSendWelcome(now, projectDate time.Time) bool {
 	cutoff := projectDate.AddDate(0, 0, -welcomeLeadDays)
-	return now.After(cutoff) && now.Before(projectDate)
+	return !now.Before(cutoff) && now.Before(projectDate)
 }
 
 func shouldSendReminder(now, projectDate time.Time) bool {

--- a/internal/app/routeproject/usecase_test.go
+++ b/internal/app/routeproject/usecase_test.go
@@ -17,7 +17,8 @@ func TestShouldSendWelcome(t *testing.T) {
 		expected bool
 	}{
 		{"8 days before - too early", projectDate.AddDate(0, 0, -8), false},
-		{"7 days before - boundary", projectDate.AddDate(0, 0, -7).Add(time.Hour), true},
+		{"7 days before - boundary (exact)", projectDate.AddDate(0, 0, -7), true},
+		{"7 days before - boundary (plus hour)", projectDate.AddDate(0, 0, -7).Add(time.Hour), true},
 		{"5 days before - in window", projectDate.AddDate(0, 0, -5), true},
 		{"1 day before - in window", projectDate.AddDate(0, 0, -1), true},
 		{"project day - too late", projectDate, false},
@@ -91,6 +92,12 @@ func TestComputeNotificationType(t *testing.T) {
 			name:        "project too far in future",
 			now:         projectDate.AddDate(0, 0, -30),
 			wantErrType: &ProjectTooFar{},
+		},
+		{
+			name:     "no existing notification, exactly 7 days before",
+			now:      projectDate.AddDate(0, 0, -7),
+			existing: nil,
+			wantType: domain.Welcome,
 		},
 		{
 			name:     "no existing notification, in welcome window",


### PR DESCRIPTION
## Summary
Fixes a one-day delay in welcome messages caused by an off-by-one at the 7-day boundary — projects seen exactly 7 days out were incorrectly skipped as `ProjectTooFar`.

## Changes
- Change `now.After(cutoff)` to `!now.Before(cutoff)` in `shouldSendWelcome` to make the 7-day boundary inclusive
- Add exact 7-day boundary test case to `TestShouldSendWelcome`
- Add exact 7-day boundary test case to `TestComputeNotificationType`