### PR TITLE
refactor(email): migrate templates from fmt.Sprintf to html/template

### DIFF
--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -5,9 +5,10 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"strings"
 )
 
-//go:embed templates
+//go:embed templates/*.html
 var templateFiles embed.FS
 
 type workflowFailedData struct {
@@ -53,7 +54,7 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 	}); err != nil {
 		panic(err)
 	}
-	htmlBody = buf.String()
+	htmlBody = strings.TrimSpace(buf.String())
 
 	return
 }
@@ -99,7 +100,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 	}); err != nil {
 		panic(err)
 	}
-	htmlBody = buf.String()
+	htmlBody = strings.TrimSpace(buf.String())
 
 	return
 }
@@ -128,7 +129,7 @@ func Completion(messageType, projectName, projectDate string, mockMode bool) (su
 	}); err != nil {
 		panic(err)
 	}
-	htmlBody = buf.String()
+	htmlBody = strings.TrimSpace(buf.String())
 
 	return
 }

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -2,9 +2,13 @@ package email
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
 	"html/template"
 )
+
+//go:embed templates
+var templateFiles embed.FS
 
 type workflowFailedData struct {
 	FailedStep   string
@@ -31,32 +35,9 @@ type approvalRequestData struct {
 	IsThankYou     bool
 }
 
-var workflowFailedTmpl = template.Must(template.New("workflowFailed").Parse(
-	`<h2>Workflow Step Failed</h2>
-<table>
-  <tr><td><strong>Step</strong></td><td>{{.FailedStep}}</td></tr>
-  <tr><td><strong>Error</strong></td><td>{{.ErrorMessage}}</td></tr>
-</table>`))
-
-var completionTmpl = template.Must(template.New("completion").Parse(
-	`<p>Successfully sent <strong>{{.MessageType}}</strong> message to <strong>{{.ProjectName}}</strong> on {{.ProjectDate}}!</p>` +
-		`<p><em>Sending to: {{.Destination}}</em></p>`))
-
-var approvalRequestTmpl = template.Must(template.New("approvalRequest").Parse(
-	`<p><strong>Project:</strong> {{.ProjectName}}<br><strong>Date:</strong> {{.ProjectDate}}<br><strong>Message Type:</strong> {{.MessageType}}<br><strong>Destination:</strong> {{.Destination}}</p>` +
-		`<p><strong>Message Content:</strong></p>` +
-		`<pre>{{.MessageContent}}</pre>` +
-		`{{if .IsThankYou}}` +
-		`<p><a href="{{.ApproveLink}}">Approve</a> &nbsp; <a href="{{.RejectLink}}">Reject</a> &nbsp; <a href="{{.RegenerateLink}}">Regenerate</a></p>` +
-		`<p><strong>Refine &amp; Regenerate:</strong></p>` +
-		`<form method="get" action="{{.RefineFormBase}}">` +
-		`<input type="hidden" name="action" value="refine">` +
-		`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>` +
-		`<input type="submit" value="Refine &amp; Regenerate">` +
-		`</form>` +
-		`{{else}}` +
-		`<p><a href="{{.ApproveLink}}">Approve</a> &nbsp; <a href="{{.RejectLink}}">Reject</a></p>` +
-		`{{end}}`))
+var workflowFailedTmpl = template.Must(template.New("workflow_failed.html").ParseFS(templateFiles, "templates/workflow_failed.html"))
+var completionTmpl = template.Must(template.New("completion.html").ParseFS(templateFiles, "templates/completion.html"))
+var approvalRequestTmpl = template.Must(template.New("approval_request.html").ParseFS(templateFiles, "templates/approval_request.html"))
 
 // WorkflowFailed returns the subject, plain text, and HTML body for a workflow step failure email.
 // errorMessage should be the human-readable error (already extracted from any JSON Cause blob).
@@ -66,10 +47,12 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 	plainText = fmt.Sprintf("Workflow step failed.\nStep: %s\nError: %s", failedStep, errorMessage)
 
 	var buf bytes.Buffer
-	_ = workflowFailedTmpl.Execute(&buf, workflowFailedData{
+	if err := workflowFailedTmpl.Execute(&buf, workflowFailedData{
 		FailedStep:   failedStep,
 		ErrorMessage: errorMessage,
-	})
+	}); err != nil {
+		panic(err)
+	}
 	htmlBody = buf.String()
 
 	return
@@ -102,7 +85,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 	}
 
 	var buf bytes.Buffer
-	_ = approvalRequestTmpl.Execute(&buf, approvalRequestData{
+	if err := approvalRequestTmpl.Execute(&buf, approvalRequestData{
 		ProjectName:    projectName,
 		ProjectDate:    projectDate,
 		MessageType:    messageType,
@@ -113,7 +96,9 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 		RegenerateLink: regenerateLink,
 		RefineFormBase: refineFormBase,
 		IsThankYou:     isThankYou,
-	})
+	}); err != nil {
+		panic(err)
+	}
 	htmlBody = buf.String()
 
 	return
@@ -135,12 +120,14 @@ func Completion(messageType, projectName, projectDate string, mockMode bool) (su
 	)
 
 	var buf bytes.Buffer
-	_ = completionTmpl.Execute(&buf, completionData{
+	if err := completionTmpl.Execute(&buf, completionData{
 		MessageType: messageType,
 		ProjectName: projectName,
 		ProjectDate: projectDate,
 		Destination: destination,
-	})
+	}); err != nil {
+		panic(err)
+	}
 	htmlBody = buf.String()
 
 	return

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -1,9 +1,62 @@
 package email
 
 import (
+	"bytes"
 	"fmt"
-	"html"
+	"html/template"
 )
+
+type workflowFailedData struct {
+	FailedStep   string
+	ErrorMessage string
+}
+
+type completionData struct {
+	MessageType string
+	ProjectName string
+	ProjectDate string
+	Destination string
+}
+
+type approvalRequestData struct {
+	ProjectName    string
+	ProjectDate    string
+	MessageType    string
+	MessageContent string
+	Destination    string
+	ApproveLink    string
+	RejectLink     string
+	RegenerateLink string
+	RefineFormBase string
+	IsThankYou     bool
+}
+
+var workflowFailedTmpl = template.Must(template.New("workflowFailed").Parse(
+	`<h2>Workflow Step Failed</h2>
+<table>
+  <tr><td><strong>Step</strong></td><td>{{.FailedStep}}</td></tr>
+  <tr><td><strong>Error</strong></td><td>{{.ErrorMessage}}</td></tr>
+</table>`))
+
+var completionTmpl = template.Must(template.New("completion").Parse(
+	`<p>Successfully sent <strong>{{.MessageType}}</strong> message to <strong>{{.ProjectName}}</strong> on {{.ProjectDate}}!</p>` +
+		`<p><em>Sending to: {{.Destination}}</em></p>`))
+
+var approvalRequestTmpl = template.Must(template.New("approvalRequest").Parse(
+	`<p><strong>Project:</strong> {{.ProjectName}}<br><strong>Date:</strong> {{.ProjectDate}}<br><strong>Message Type:</strong> {{.MessageType}}<br><strong>Destination:</strong> {{.Destination}}</p>` +
+		`<p><strong>Message Content:</strong></p>` +
+		`<pre>{{.MessageContent}}</pre>` +
+		`{{if .IsThankYou}}` +
+		`<p><a href="{{.ApproveLink}}">Approve</a> &nbsp; <a href="{{.RejectLink}}">Reject</a> &nbsp; <a href="{{.RegenerateLink}}">Regenerate</a></p>` +
+		`<p><strong>Refine &amp; Regenerate:</strong></p>` +
+		`<form method="get" action="{{.RefineFormBase}}">` +
+		`<input type="hidden" name="action" value="refine">` +
+		`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>` +
+		`<input type="submit" value="Refine &amp; Regenerate">` +
+		`</form>` +
+		`{{else}}` +
+		`<p><a href="{{.ApproveLink}}">Approve</a> &nbsp; <a href="{{.RejectLink}}">Reject</a></p>` +
+		`{{end}}`))
 
 // WorkflowFailed returns the subject, plain text, and HTML body for a workflow step failure email.
 // errorMessage should be the human-readable error (already extracted from any JSON Cause blob).
@@ -12,14 +65,12 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 
 	plainText = fmt.Sprintf("Workflow step failed.\nStep: %s\nError: %s", failedStep, errorMessage)
 
-	htmlBody = fmt.Sprintf(`<h2>Workflow Step Failed</h2>
-<table>
-  <tr><td><strong>Step</strong></td><td>%s</td></tr>
-  <tr><td><strong>Error</strong></td><td>%s</td></tr>
-</table>`,
-		html.EscapeString(failedStep),
-		html.EscapeString(errorMessage),
-	)
+	var buf bytes.Buffer
+	_ = workflowFailedTmpl.Execute(&buf, workflowFailedData{
+		FailedStep:   failedStep,
+		ErrorMessage: errorMessage,
+	})
+	htmlBody = buf.String()
 
 	return
 }
@@ -43,46 +94,27 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s\n\nRegenerate: %s\n\nRefine: %s&action=refine&context=YOUR+CONTEXT+HERE",
 			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase,
 		)
-		htmlBody = fmt.Sprintf(
-			`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
-				`<p><strong>Message Content:</strong></p>`+
-				`<pre>%s</pre>`+
-				`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a> &nbsp; <a href="%s">Regenerate</a></p>`+
-				`<p><strong>Refine &amp; Regenerate:</strong></p>`+
-				`<form method="get" action="%s">`+
-				`<input type="hidden" name="action" value="refine">`+
-				`<textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>`+
-				`<input type="submit" value="Refine &amp; Regenerate">`+
-				`</form>`,
-			html.EscapeString(projectName),
-			html.EscapeString(projectDate),
-			html.EscapeString(messageType),
-			html.EscapeString(destination),
-			html.EscapeString(messageContent),
-			html.EscapeString(approveLink),
-			html.EscapeString(rejectLink),
-			html.EscapeString(regenerateLink),
-			html.EscapeString(refineFormBase),
-		)
 	} else {
 		plainText = fmt.Sprintf(
 			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s",
 			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink,
 		)
-		htmlBody = fmt.Sprintf(
-			`<p><strong>Project:</strong> %s<br><strong>Date:</strong> %s<br><strong>Message Type:</strong> %s<br><strong>Destination:</strong> %s</p>`+
-				`<p><strong>Message Content:</strong></p>`+
-				`<pre>%s</pre>`+
-				`<p><a href="%s">Approve</a> &nbsp; <a href="%s">Reject</a></p>`,
-			html.EscapeString(projectName),
-			html.EscapeString(projectDate),
-			html.EscapeString(messageType),
-			html.EscapeString(destination),
-			html.EscapeString(messageContent),
-			html.EscapeString(approveLink),
-			html.EscapeString(rejectLink),
-		)
 	}
+
+	var buf bytes.Buffer
+	_ = approvalRequestTmpl.Execute(&buf, approvalRequestData{
+		ProjectName:    projectName,
+		ProjectDate:    projectDate,
+		MessageType:    messageType,
+		MessageContent: messageContent,
+		Destination:    destination,
+		ApproveLink:    approveLink,
+		RejectLink:     rejectLink,
+		RegenerateLink: regenerateLink,
+		RefineFormBase: refineFormBase,
+		IsThankYou:     isThankYou,
+	})
+	htmlBody = buf.String()
 
 	return
 }
@@ -102,14 +134,14 @@ func Completion(messageType, projectName, projectDate string, mockMode bool) (su
 		messageType, projectName, projectDate, destination,
 	)
 
-	htmlBody = fmt.Sprintf(
-		`<p>Successfully sent <strong>%s</strong> message to <strong>%s</strong> on %s!</p>`+
-			`<p><em>Sending to: %s</em></p>`,
-		html.EscapeString(messageType),
-		html.EscapeString(projectName),
-		html.EscapeString(projectDate),
-		html.EscapeString(destination),
-	)
+	var buf bytes.Buffer
+	_ = completionTmpl.Execute(&buf, completionData{
+		MessageType: messageType,
+		ProjectName: projectName,
+		ProjectDate: projectDate,
+		Destination: destination,
+	})
+	htmlBody = buf.String()
 
 	return
 }

--- a/internal/email/templates/approval_request.html
+++ b/internal/email/templates/approval_request.html
@@ -1,0 +1,26 @@
+<p>
+  <strong>Project:</strong> {{.ProjectName}}<br>
+  <strong>Date:</strong> {{.ProjectDate}}<br>
+  <strong>Message Type:</strong> {{.MessageType}}<br>
+  <strong>Destination:</strong> {{.Destination}}
+</p>
+<p><strong>Message Content:</strong></p>
+<pre>{{.MessageContent}}</pre>
+{{if .IsThankYou}}
+<p>
+  <a href="{{.ApproveLink}}">Approve</a> &nbsp;
+  <a href="{{.RejectLink}}">Reject</a> &nbsp;
+  <a href="{{.RegenerateLink}}">Regenerate</a>
+</p>
+<p><strong>Refine &amp; Regenerate:</strong></p>
+<form method="get" action="{{.RefineFormBase}}">
+  <input type="hidden" name="action" value="refine">
+  <textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>
+  <input type="submit" value="Refine &amp; Regenerate">
+</form>
+{{else}}
+<p>
+  <a href="{{.ApproveLink}}">Approve</a> &nbsp;
+  <a href="{{.RejectLink}}">Reject</a>
+</p>
+{{end}}

--- a/internal/email/templates/completion.html
+++ b/internal/email/templates/completion.html
@@ -1,0 +1,2 @@
+<p>Successfully sent <strong>{{.MessageType}}</strong> message to <strong>{{.ProjectName}}</strong> on {{.ProjectDate}}!</p>
+<p><em>Sending to: {{.Destination}}</em></p>

--- a/internal/email/templates/workflow_failed.html
+++ b/internal/email/templates/workflow_failed.html
@@ -1,0 +1,5 @@
+<h2>Workflow Step Failed</h2>
+<table>
+  <tr><td><strong>Step</strong></td><td>{{.FailedStep}}</td></tr>
+  <tr><td><strong>Error</strong></td><td>{{.ErrorMessage}}</td></tr>
+</table>


### PR DESCRIPTION
## Summary
Replaces `fmt.Sprintf` + manual `html.EscapeString()` calls in email templates with Go's stdlib `html/template` for automatic context-aware escaping. No behavior change, no new dependencies.

## Changes
- Add typed data structs (`workflowFailedData`, `completionData`, `approvalRequestData`) for each template
- Define package-level `template.Must` template variables for all three email functions
- Replace `fmt.Sprintf` HTML construction with `template.Execute` into a `bytes.Buffer`
- Remove `html` import; add `bytes` and `html/template`