### PR TITLE
fix(email): use past tense in completion email

### DIFF
--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -116,7 +116,7 @@ func Completion(messageType, projectName, projectDate string, mockMode bool) (su
 	}
 
 	plainText = fmt.Sprintf(
-		"Successfully sent %s message to %s on %s!\n\nSending to: %s",
+		"Successfully sent %s message to %s on %s!\n\nSent to: %s",
 		messageType, projectName, projectDate, destination,
 	)
 

--- a/internal/email/templates/completion.html
+++ b/internal/email/templates/completion.html
@@ -1,2 +1,2 @@
 <p>Successfully sent <strong>{{.MessageType}}</strong> message to <strong>{{.ProjectName}}</strong> on {{.ProjectDate}}!</p>
-<p><em>Sending to: {{.Destination}}</em></p>
+<p><em>Sent to: {{.Destination}}</em></p>


### PR DESCRIPTION
## Summary
Fixes inconsistent tense in the completion email — "Sending to" used present tense while "Successfully sent" used past tense in the same message.

## Changes
- Change "Sending to: X" → "Sent to: X" in `completion.html`
- Apply the same fix to the plain text body in `templates.go`

Closes #60