### PR TITLE
fix(ci): correct Lambda package names in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-stale-envs.yml
+++ b/.github/workflows/cleanup-stale-envs.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build lambdas
         if: steps.ci-check.outputs.skip == 'false'
         run: |
-          for pkg in login fetchprojects computemessagetosend requestapprovaltosend sendandpinmessage recordmessage notifycompletion dlqnotifier approvalcallback sesforwarder; do
+          for pkg in login fetchprojects routeproject computepreprojectmessage generatethankyoumessage requestapprovaltosend sendandpinmessage recordmessage notifycompletion dlqnotifier approvalcallback sesforwarder; do
             mkdir -p lambda-build/$pkg
             CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o lambda-build/$pkg/bootstrap ./lambda/$pkg &
           done


### PR DESCRIPTION
## Summary
The cleanup workflow's Lambda build loop referenced `computemessagetosend` (nonexistent) and was missing `routeproject` and `generatethankyoumessage`, causing silent build failures that left stale CI environments running.

## Changes
- Replace `computemessagetosend` with `routeproject`, `computepreprojectmessage`, and `generatethankyoumessage` in the cleanup workflow build loop

Closes #66