### PR TITLE
fix(sesforwarder): add ok-check to SNS attribute type assertion

### DIFF
--- a/lambda/sesforwarder/handler.go
+++ b/lambda/sesforwarder/handler.go
@@ -31,7 +31,8 @@ func (h *SESForwarderHandler) Handle(ctx context.Context, event events.SNSEvent)
 		}
 
 		attr, hasFormat := msg.MessageAttributes["format"]
-		if hasFormat && attr.(map[string]interface{})["Value"] == "html" {
+		attrMap, attrIsMap := attr.(map[string]interface{})
+		if hasFormat && attrIsMap && attrMap["Value"] == "html" {
 			var payload htmlPayload
 			if err := json.Unmarshal([]byte(msg.Message), &payload); err != nil {
 				slog.Error("sesforwarder failed to parse HTML payload", "error", err)


### PR DESCRIPTION
## Summary
Fixes a potential panic in `SESForwarder` caused by an unchecked type assertion on an SNS message attribute.

## Changes
- Replace bare type assertion `attr.(map[string]interface{})` with a two-value ok-check in `lambda/sesforwarder/handler.go`
- Falls back to the plain-text email path when the assertion fails, consistent with behavior for missing attributes