### PR TITLE
fix(email): return error from template functions instead of panicking

### DIFF
--- a/cmd/emailpreview/main.go
+++ b/cmd/emailpreview/main.go
@@ -32,13 +32,17 @@ func main() {
 			suffix = "-mock"
 		}
 
-		s, p, h := email.WorkflowFailed(
+		s, p, h, err := email.WorkflowFailed(
 			"SendAndPinMessage",
 			"connection to NYC Cares API timed out after 30s",
 		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to render workflow-failed email: %v\n", err)
+			os.Exit(1)
+		}
 		emails = append(emails, entry{"workflow-failed" + suffix, s, p, h})
 
-		s, p, h = email.ApprovalRequest(
+		s, p, h, err = email.ApprovalRequest(
 			"Central Park Cleanup",
 			"2026-04-10",
 			"welcome",
@@ -49,9 +53,17 @@ func main() {
 			"http://localhost:4566/callback?token=abc123&secret=test-secret",
 			mockMode,
 		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to render approval-request email: %v\n", err)
+			os.Exit(1)
+		}
 		emails = append(emails, entry{"approval-request" + suffix, s, p, h})
 
-		s, p, h = email.Completion("reminder", "Brooklyn Food Bank", "2026-04-15", mockMode)
+		s, p, h, err = email.Completion("reminder", "Brooklyn Food Bank", "2026-04-15", mockMode)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to render completion email: %v\n", err)
+			os.Exit(1)
+		}
 		emails = append(emails, entry{"completion" + suffix, s, p, h})
 	}
 

--- a/internal/app/dlqnotifier/usecase.go
+++ b/internal/app/dlqnotifier/usecase.go
@@ -30,9 +30,12 @@ func (u *DLQNotifierUseCase) Execute(ctx context.Context, errorInfo models.DLQNo
 		errorMessage = cause.ErrorMessage
 	}
 
-	subject, plainText, htmlBody := email.WorkflowFailed(errorInfo.FailedStep, errorMessage)
+	subject, plainText, htmlBody, err := email.WorkflowFailed(errorInfo.FailedStep, errorMessage)
+	if err != nil {
+		return fmt.Errorf("failed to render workflow failed email: %w", err)
+	}
 
-	_, err := u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
+	_, err = u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
 	if err != nil {
 		return fmt.Errorf("failed to publish DLQ notification: %w", err)
 	}

--- a/internal/app/notifycompletion/usecase.go
+++ b/internal/app/notifycompletion/usecase.go
@@ -28,9 +28,12 @@ func (u *NotifyCompletionUseCase) Execute(
 ) error {
 
 	projectDate := utils.DateToString(project.Date)
-	subject, plainText, htmlBody := email.Completion(notificationType.String(), project.Name, projectDate, mockMode)
+	subject, plainText, htmlBody, err := email.Completion(notificationType.String(), project.Name, projectDate, mockMode)
+	if err != nil {
+		return fmt.Errorf("failed to render completion email: %w", err)
+	}
 
-	_, err := u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
+	_, err = u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
 	if err != nil {
 		return fmt.Errorf("failed to publish completion notification: %w", err)
 	}

--- a/internal/app/requestapproval/usecase.go
+++ b/internal/app/requestapproval/usecase.go
@@ -48,9 +48,12 @@ func (u *RequestApprovalUseCase) Execute(ctx context.Context, callbackEndpoint u
 	regenerateLink := buildCallbackLink(callbackEndpoint, taskToken, "regenerate", u.approvalSecret)
 	refineFormBase := buildRefineFormBase(callbackEndpoint, taskToken, u.approvalSecret)
 
-	subject, plainText, htmlBody := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, mockMode)
+	subject, plainText, htmlBody, err := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, mockMode)
+	if err != nil {
+		return fmt.Errorf("failed to render approval request email: %w", err)
+	}
 
-	_, err := u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
+	_, err = u.snsSrv.PublishHTMLEmailNotification(ctx, plainText, htmlBody, subject)
 	if err != nil {
 		return fmt.Errorf("failed to publish approval notification: %w", err)
 	}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -42,17 +42,17 @@ var approvalRequestTmpl = template.Must(template.New("approval_request.html").Pa
 
 // WorkflowFailed returns the subject, plain text, and HTML body for a workflow step failure email.
 // errorMessage should be the human-readable error (already extracted from any JSON Cause blob).
-func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBody string) {
+func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBody string, err error) {
 	subject = "NYC Cares Project Welcomer \u2014 Workflow Step Failed"
 
 	plainText = fmt.Sprintf("Workflow step failed.\nStep: %s\nError: %s", failedStep, errorMessage)
 
 	var buf bytes.Buffer
-	if err := workflowFailedTmpl.Execute(&buf, workflowFailedData{
+	if err = workflowFailedTmpl.Execute(&buf, workflowFailedData{
 		FailedStep:   failedStep,
 		ErrorMessage: errorMessage,
 	}); err != nil {
-		panic(err)
+		return
 	}
 	htmlBody = strings.TrimSpace(buf.String())
 
@@ -63,7 +63,7 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 // mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
 // regenerateLink triggers a fresh generation with no additional context (thankYou only).
 // refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement (thankYou only).
-func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase string, mockMode bool) (subject, plainText, htmlBody string) {
+func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Project Message Approval"
 
 	destination := "real NYC Cares platform"
@@ -86,7 +86,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 	}
 
 	var buf bytes.Buffer
-	if err := approvalRequestTmpl.Execute(&buf, approvalRequestData{
+	if err = approvalRequestTmpl.Execute(&buf, approvalRequestData{
 		ProjectName:    projectName,
 		ProjectDate:    projectDate,
 		MessageType:    messageType,
@@ -98,7 +98,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 		RefineFormBase: refineFormBase,
 		IsThankYou:     isThankYou,
 	}); err != nil {
-		panic(err)
+		return
 	}
 	htmlBody = strings.TrimSpace(buf.String())
 
@@ -107,7 +107,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 
 // Completion returns the subject, plain text, and HTML body for a successful message send notification.
 // mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
-func Completion(messageType, projectName, projectDate string, mockMode bool) (subject, plainText, htmlBody string) {
+func Completion(messageType, projectName, projectDate string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Message Sent!"
 
 	destination := "real NYC Cares platform"
@@ -121,13 +121,13 @@ func Completion(messageType, projectName, projectDate string, mockMode bool) (su
 	)
 
 	var buf bytes.Buffer
-	if err := completionTmpl.Execute(&buf, completionData{
+	if err = completionTmpl.Execute(&buf, completionData{
 		MessageType: messageType,
 		ProjectName: projectName,
 		ProjectDate: projectDate,
 		Destination: destination,
 	}); err != nil {
-		panic(err)
+		return
 	}
 	htmlBody = strings.TrimSpace(buf.String())
 

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func TestWorkflowFailed_Subject(t *testing.T) {
-	subject, _, _ := WorkflowFailed("Login", "connection refused")
+	subject, _, _, err := WorkflowFailed("Login", "connection refused")
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := "NYC Cares Project Welcomer \u2014 Workflow Step Failed"
 	if subject != want {
 		t.Errorf("subject = %q, want %q", subject, want)
@@ -14,7 +17,10 @@ func TestWorkflowFailed_Subject(t *testing.T) {
 }
 
 func TestWorkflowFailed_ContainsFields(t *testing.T) {
-	_, plainText, htmlBody := WorkflowFailed("FetchProjects", "timeout after 30s")
+	_, plainText, htmlBody, err := WorkflowFailed("FetchProjects", "timeout after 30s")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, s := range []string{"FetchProjects", "timeout after 30s"} {
 		if !strings.Contains(plainText, s) {
@@ -27,7 +33,10 @@ func TestWorkflowFailed_ContainsFields(t *testing.T) {
 }
 
 func TestWorkflowFailed_HTMLEscaping(t *testing.T) {
-	_, _, htmlBody := WorkflowFailed("<b>Step</b>", `<script>alert(1)</script>`)
+	_, _, htmlBody, err := WorkflowFailed("<b>Step</b>", `<script>alert(1)</script>`)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if strings.Contains(htmlBody, "<script>") {
 		t.Error("htmlBody should escape <script> in errorMessage")
@@ -41,7 +50,10 @@ func TestWorkflowFailed_HTMLEscaping(t *testing.T) {
 }
 
 func TestWorkflowFailed_NoErrorTypeNoise(t *testing.T) {
-	_, plainText, htmlBody := WorkflowFailed("Login", "connection refused")
+	_, plainText, htmlBody, err := WorkflowFailed("Login", "connection refused")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, noise := range []string{"errorType", "errorString", "stackTrace"} {
 		if strings.Contains(plainText, noise) {
@@ -54,14 +66,20 @@ func TestWorkflowFailed_NoErrorTypeNoise(t *testing.T) {
 }
 
 func TestApprovalRequest_Subject(t *testing.T) {
-	subject, _, _ := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	subject, _, _, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if subject != "Project Message Approval" {
 		t.Errorf("subject = %q, want %q", subject, "Project Message Approval")
 	}
 }
 
 func TestApprovalRequest_ContainsFields(t *testing.T) {
-	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject"}
 	for _, s := range checks {
@@ -85,10 +103,13 @@ func TestApprovalRequest_ContainsFields(t *testing.T) {
 }
 
 func TestApprovalRequest_HTMLEscaping(t *testing.T) {
-	_, _, htmlBody := ApprovalRequest(
+	_, _, htmlBody, err := ApprovalRequest(
 		"<Project>", "<date>", "<type>", "<script>xss</script>",
 		"http://approve", "http://reject", "http://regenerate", "http://refine-base", false,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, raw := range []string{"<Project>", "<date>", "<type>", "<script>"} {
 		if strings.Contains(htmlBody, raw) {
@@ -98,7 +119,10 @@ func TestApprovalRequest_HTMLEscaping(t *testing.T) {
 }
 
 func TestApprovalRequest_MockMode(t *testing.T) {
-	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", true)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !strings.Contains(plainText, "mock server") {
 		t.Error("plainText should indicate mock server when mockMode=true")
@@ -107,7 +131,10 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 		t.Error("htmlBody should indicate mock server when mockMode=true")
 	}
 
-	_, plainText2, htmlBody2 := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText2, htmlBody2, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(plainText2, "real NYC Cares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
@@ -117,7 +144,10 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 }
 
 func TestApprovalRequest_ContainsRegenerateAndRefine(t *testing.T) {
-	_, plainText, htmlBody := ApprovalRequest("Park Cleanup", "2026-04-10", "thankYou", "Thanks!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "thankYou", "Thanks!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !strings.Contains(plainText, "http://regenerate") {
 		t.Error("plainText missing regenerate link")
@@ -134,14 +164,20 @@ func TestApprovalRequest_ContainsRegenerateAndRefine(t *testing.T) {
 }
 
 func TestCompletion_Subject(t *testing.T) {
-	subject, _, _ := Completion("welcome", "Park Cleanup", "2026-04-10", false)
+	subject, _, _, err := Completion("welcome", "Park Cleanup", "2026-04-10", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if subject != "Message Sent!" {
 		t.Errorf("subject = %q, want %q", subject, "Message Sent!")
 	}
 }
 
 func TestCompletion_ContainsFields(t *testing.T) {
-	_, plainText, htmlBody := Completion("reminder", "Food Bank", "2026-04-15", false)
+	_, plainText, htmlBody, err := Completion("reminder", "Food Bank", "2026-04-15", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, s := range []string{"reminder", "Food Bank", "2026-04-15"} {
 		if !strings.Contains(plainText, s) {
@@ -154,7 +190,10 @@ func TestCompletion_ContainsFields(t *testing.T) {
 }
 
 func TestCompletion_HTMLEscaping(t *testing.T) {
-	_, _, htmlBody := Completion("<b>welcome</b>", "<Project & Name>", "2026-04-15", false)
+	_, _, htmlBody, err := Completion("<b>welcome</b>", "<Project & Name>", "2026-04-15", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if strings.Contains(htmlBody, "<b>welcome</b>") {
 		t.Error("htmlBody should escape HTML in messageType")
@@ -165,7 +204,10 @@ func TestCompletion_HTMLEscaping(t *testing.T) {
 }
 
 func TestCompletion_MockMode(t *testing.T) {
-	_, plainText, htmlBody := Completion("welcome", "Park Cleanup", "2026-04-10", true)
+	_, plainText, htmlBody, err := Completion("welcome", "Park Cleanup", "2026-04-10", true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !strings.Contains(plainText, "mock server") {
 		t.Error("plainText should indicate mock server when mockMode=true")
@@ -174,7 +216,10 @@ func TestCompletion_MockMode(t *testing.T) {
 		t.Error("htmlBody should indicate mock server when mockMode=true")
 	}
 
-	_, plainText2, htmlBody2 := Completion("welcome", "Park Cleanup", "2026-04-10", false)
+	_, plainText2, htmlBody2, err := Completion("welcome", "Park Cleanup", "2026-04-10", false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(plainText2, "real NYC Cares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}


### PR DESCRIPTION
## Summary
Replaces `panic(err)` with proper error returns in the three email template functions so failures surface as Step Functions errors instead of crashing the Lambda process.

## Changes
- Add `error` as a fourth return value to `WorkflowFailed`, `ApprovalRequest`, and `Completion` in `internal/email/templates.go`
- Update `dlqnotifier`, `notifycompletion`, and `requestapproval` use cases to propagate the new error return
- Update `cmd/emailpreview/main.go` and `internal/email/templates_test.go` to match the new signatures

Closes #68