### PR TITLE
security: harden S3 bucket with encryption, public access blocking, and versioning

### DIFF
--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -103,8 +103,11 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		})
 
 		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
-			BucketName:    jsii.String(bucketName),
-			RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+			BucketName:        jsii.String(bucketName),
+			RemovalPolicy:     awscdk.RemovalPolicy_DESTROY,
+			Versioned:         jsii.Bool(true),
+			Encryption:        awss3.BucketEncryption_S3_MANAGED,
+			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),
 		})
 
 	} else {


### PR DESCRIPTION
## Summary

- Adds `Versioned: true` to the message template S3 bucket so accidental template deletions can be recovered
- Sets `Encryption: S3_MANAGED` to make encryption intent explicit rather than relying on AWS defaults
- Sets `BlockPublicAccess: BLOCK_ALL` to prevent accidental public exposure via misconfigured bucket policies

## Changes

- `infra/stack/projectnotifierstack.go`: updated `MessageTemplates` bucket CDK props with versioning, S3-managed encryption, and full public access blocking

Closes #70