### PR TITLE
security: move approval secret from URL query param to POST body

### DIFF
--- a/cmd/emailpreview/main.go
+++ b/cmd/emailpreview/main.go
@@ -47,10 +47,11 @@ func main() {
 			"2026-04-10",
 			"welcome",
 			"Hi volunteers! We're excited to have you join us for Central Park Cleanup on April 10th. Please arrive at the Visitor Center by 9am.",
-			"http://localhost:4566/callback?token=abc123&action=approve&secret=test-secret",
-			"http://localhost:4566/callback?token=abc123&action=reject&secret=test-secret",
-			"http://localhost:4566/callback?token=abc123&action=regenerate&secret=test-secret",
-			"http://localhost:4566/callback?token=abc123&secret=test-secret",
+			"http://localhost:4566/callback?token=abc123&action=approve",
+			"http://localhost:4566/callback?token=abc123&action=reject",
+			"http://localhost:4566/callback?token=abc123&action=regenerate",
+			"http://localhost:4566/callback?token=abc123",
+			"test-secret",
 			mockMode,
 		)
 		if err != nil {

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -286,6 +286,11 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		awsapigateway.NewLambdaIntegration(approvalCallbackFn, nil),
 		nil,
 	)
+	callbackResource.AddMethod(
+		jsii.String("POST"),
+		awsapigateway.NewLambdaIntegration(approvalCallbackFn, nil),
+		nil,
+	)
 
 	// Set the callback endpoint from the API Gateway URL (resolved at deploy time)
 	lambdaFns["RequestApprovalToSend"].AddEnvironment(

--- a/internal/app/requestapproval/usecase.go
+++ b/internal/app/requestapproval/usecase.go
@@ -48,7 +48,7 @@ func (u *RequestApprovalUseCase) Execute(ctx context.Context, callbackEndpoint u
 	regenerateLink := buildCallbackLink(callbackEndpoint, taskToken, "regenerate", u.approvalSecret)
 	refineFormBase := buildRefineFormBase(callbackEndpoint, taskToken, u.approvalSecret)
 
-	subject, plainText, htmlBody, err := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, mockMode)
+	subject, plainText, htmlBody, err := email.ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, u.approvalSecret, mockMode)
 	if err != nil {
 		return fmt.Errorf("failed to render approval request email: %w", err)
 	}
@@ -66,9 +66,6 @@ func buildCallbackLink(baseURL url.URL, taskToken string, action string, secret 
 	q := baseURL.Query()
 	q.Set("token", taskToken)
 	q.Set("action", action)
-	if secret != "" {
-		q.Set("secret", secret)
-	}
 	baseURL.RawQuery = q.Encode()
 	return baseURL.String()
 }
@@ -80,9 +77,6 @@ func buildRefineFormBase(baseURL url.URL, taskToken string, secret string) strin
 	appendCallbackPath(&baseURL)
 	q := baseURL.Query()
 	q.Set("token", taskToken)
-	if secret != "" {
-		q.Set("secret", secret)
-	}
 	baseURL.RawQuery = q.Encode()
 	return baseURL.String()
 }

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -34,6 +34,7 @@ type approvalRequestData struct {
 	RegenerateLink string
 	RefineFormBase string
 	IsThankYou     bool
+	Secret         string
 }
 
 var workflowFailedTmpl = template.Must(template.New("workflow_failed.html").ParseFS(templateFiles, "templates/workflow_failed.html"))
@@ -63,7 +64,7 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 // mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
 // regenerateLink triggers a fresh generation with no additional context (thankYou only).
 // refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement (thankYou only).
-func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase string, mockMode bool) (subject, plainText, htmlBody string, err error) {
+func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, secret string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Project Message Approval"
 
 	destination := "real NYC Cares platform"
@@ -75,13 +76,13 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 
 	if isThankYou {
 		plainText = fmt.Sprintf(
-			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s\n\nRegenerate: %s\n\nRefine: %s&action=refine&context=YOUR+CONTEXT+HERE",
-			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase,
+			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nPlease use the HTML version of this email to approve, reject, regenerate, or refine this message.",
+			projectName, projectDate, messageType, destination, messageContent,
 		)
 	} else {
 		plainText = fmt.Sprintf(
-			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nApprove: %s\n\nReject: %s",
-			projectName, projectDate, messageType, destination, messageContent, approveLink, rejectLink,
+			"Project: %s\nDate: %s\nMessage Type: %s\nDestination: %s\n\nMessage Content:\n%s\n\nPlease use the HTML version of this email to approve or reject this message.",
+			projectName, projectDate, messageType, destination, messageContent,
 		)
 	}
 
@@ -97,6 +98,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 		RegenerateLink: regenerateLink,
 		RefineFormBase: refineFormBase,
 		IsThankYou:     isThankYou,
+		Secret:         secret,
 	}); err != nil {
 		return
 	}

--- a/internal/email/templates/approval_request.html
+++ b/internal/email/templates/approval_request.html
@@ -8,19 +8,38 @@
 <pre>{{.MessageContent}}</pre>
 {{if .IsThankYou}}
 <p>
-  <a href="{{.ApproveLink}}">Approve</a> &nbsp;
-  <a href="{{.RejectLink}}">Reject</a> &nbsp;
-  <a href="{{.RegenerateLink}}">Regenerate</a>
+  <form method="post" action="{{.ApproveLink}}" style="display:inline">
+    {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+    <button type="submit">Approve</button>
+  </form>
+  &nbsp;
+  <form method="post" action="{{.RejectLink}}" style="display:inline">
+    {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+    <button type="submit">Reject</button>
+  </form>
+  &nbsp;
+  <form method="post" action="{{.RegenerateLink}}" style="display:inline">
+    {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+    <button type="submit">Regenerate</button>
+  </form>
 </p>
 <p><strong>Refine &amp; Regenerate:</strong></p>
-<form method="get" action="{{.RefineFormBase}}">
+<form method="post" action="{{.RefineFormBase}}">
+  {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
   <input type="hidden" name="action" value="refine">
   <textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>
   <input type="submit" value="Refine &amp; Regenerate">
 </form>
 {{else}}
 <p>
-  <a href="{{.ApproveLink}}">Approve</a> &nbsp;
-  <a href="{{.RejectLink}}">Reject</a>
+  <form method="post" action="{{.ApproveLink}}" style="display:inline">
+    {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+    <button type="submit">Approve</button>
+  </form>
+  &nbsp;
+  <form method="post" action="{{.RejectLink}}" style="display:inline">
+    {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+    <button type="submit">Reject</button>
+  </form>
 </p>
 {{end}}

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -66,7 +66,7 @@ func TestWorkflowFailed_NoErrorTypeNoise(t *testing.T) {
 }
 
 func TestApprovalRequest_Subject(t *testing.T) {
-	subject, _, _, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	subject, _, _, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,16 +76,19 @@ func TestApprovalRequest_Subject(t *testing.T) {
 }
 
 func TestApprovalRequest_ContainsFields(t *testing.T) {
-	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	checks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject"}
-	for _, s := range checks {
+	plainChecks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!"}
+	for _, s := range plainChecks {
 		if !strings.Contains(plainText, s) {
 			t.Errorf("plainText missing %q", s)
 		}
+	}
+	htmlChecks := []string{"Park Cleanup", "2026-04-10", "welcome", "Hello volunteers!", "http://approve", "http://reject"}
+	for _, s := range htmlChecks {
 		if !strings.Contains(htmlBody, s) {
 			t.Errorf("htmlBody missing %q", s)
 		}
@@ -105,7 +108,7 @@ func TestApprovalRequest_ContainsFields(t *testing.T) {
 func TestApprovalRequest_HTMLEscaping(t *testing.T) {
 	_, _, htmlBody, err := ApprovalRequest(
 		"<Project>", "<date>", "<type>", "<script>xss</script>",
-		"http://approve", "http://reject", "http://regenerate", "http://refine-base", false,
+		"http://approve", "http://reject", "http://regenerate", "http://refine-base", "", false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -119,7 +122,7 @@ func TestApprovalRequest_HTMLEscaping(t *testing.T) {
 }
 
 func TestApprovalRequest_MockMode(t *testing.T) {
-	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", true)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", "", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +134,7 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 		t.Error("htmlBody should indicate mock server when mockMode=true")
 	}
 
-	_, plainText2, htmlBody2, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText2, htmlBody2, err := ApprovalRequest("Park Cleanup", "2026-04-10", "welcome", "content", "http://approve", "http://reject", "http://regenerate", "http://refine-base", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,13 +147,13 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 }
 
 func TestApprovalRequest_ContainsRegenerateAndRefine(t *testing.T) {
-	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "thankYou", "Thanks!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", false)
+	_, plainText, htmlBody, err := ApprovalRequest("Park Cleanup", "2026-04-10", "thankYou", "Thanks!", "http://approve", "http://reject", "http://regenerate", "http://refine-base", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(plainText, "http://regenerate") {
-		t.Error("plainText missing regenerate link")
+	if !strings.Contains(plainText, "HTML version") {
+		t.Error("plainText should direct user to HTML version")
 	}
 	if !strings.Contains(htmlBody, "Regenerate") {
 		t.Error("htmlBody missing Regenerate option")

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/base64"
 	"fmt"
 	"html"
 	"log/slog"
+	"net/url"
 
 	ac "github.com/Bouzomgi/nycares-project-welcomer/internal/app/approvalcallback"
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/config"
@@ -22,14 +24,31 @@ func NewApprovalCallbackHandler(u *ac.ApprovalCallbackUseCase, cfg *ac.Config) *
 }
 
 func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	slog.Info("approvalcallback handler invoked", "action", request.QueryStringParameters["action"])
+	bodyParams := url.Values{}
+	if request.Body != "" {
+		body := request.Body
+		if request.IsBase64Encoded {
+			if decoded, err := base64.StdEncoding.DecodeString(body); err == nil {
+				body = string(decoded)
+			}
+		}
+		bodyParams, _ = url.ParseQuery(body)
+	}
+	getParam := func(key string) string {
+		if v := bodyParams.Get(key); v != "" {
+			return v
+		}
+		return request.QueryStringParameters[key]
+	}
+
+	slog.Info("approvalcallback handler invoked", "action", getParam("action"))
 
 	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	// Validate shared secret if configured
 	if expectedSecret := h.cfg.AWS.SF.ApprovalSecret; expectedSecret != "" {
-		providedSecret := request.QueryStringParameters["secret"]
+		providedSecret := getParam("secret")
 		if subtle.ConstantTimeCompare([]byte(expectedSecret), []byte(providedSecret)) != 1 {
 			slog.Warn("approvalcallback rejected: invalid secret")
 			return events.APIGatewayProxyResponse{
@@ -40,9 +59,9 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		}
 	}
 
-	token := request.QueryStringParameters["token"]
-	action := request.QueryStringParameters["action"]
-	refinementContext := request.QueryStringParameters["context"]
+	token := getParam("token")
+	action := getParam("action")
+	refinementContext := getParam("context")
 	if len(refinementContext) > 500 {
 		refinementContext = refinementContext[:500]
 	}


### PR DESCRIPTION
## Summary

- Secret was previously passed as `?secret=...` in callback URLs, making it visible in CloudWatch logs, API Gateway access logs, browser history, and CDN caches
- Approval action links (`approve`, `reject`, `regenerate`, `refine`) are now rendered as POST forms with the secret in a hidden field instead of `<a href>` GET links
- API Gateway callback resource now accepts both `GET` and `POST`; handler reads params from the POST body first, falling back to query string for backward compatibility
- Plain text email body no longer contains action URLs (directs user to HTML version instead)

## Changes

- `internal/app/requestapproval/usecase.go` — removed `secret` from `buildCallbackLink` and `buildRefineFormBase` query params; passes secret separately to `email.ApprovalRequest`
- `internal/email/templates.go` — added `secret string` param to `ApprovalRequest`; updated plain text to direct users to HTML version
- `internal/email/templates/approval_request.html` — converted `<a href>` links to POST forms with hidden `secret` field; changed refine form from GET to POST
- `lambda/approvalcallback/handler.go` — added POST body parsing with `getParam` helper (body-first, query-string fallback)
- `infra/stack/projectnotifierstack.go` — added `POST` method to the `/callback` API Gateway resource
- `cmd/emailpreview/main.go` + `internal/email/templates_test.go` — updated for new `ApprovalRequest` signature

Closes #72