### PR TITLE
ops: add retry with exponential backoff for transient HTTP failures

### DIFF
--- a/internal/platform/http/service/httpservice.go
+++ b/internal/platform/http/service/httpservice.go
@@ -30,12 +30,45 @@ func NewHttpService(baseUrl string) (*HttpService, error) {
 }
 
 func (s *HttpService) SendRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	const maxAttempts = 3
+	baseDelay := time.Second
+
 	req = req.WithContext(ctx)
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+
+	var lastErr error
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, fmt.Errorf("failed to reset request body for retry: %w", err)
+				}
+				req.Body = body
+			}
+			delay := baseDelay * time.Duration(1<<(attempt-1))
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		resp, err := s.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %w", err)
+			continue
+		}
+
+		if resp.StatusCode >= 500 {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("request failed with status %d", resp.StatusCode)
+			continue
+		}
+
+		return resp, nil
 	}
-	return resp, nil
+
+	return nil, lastErr
 }
 
 func (s *HttpService) ReadBody(resp *http.Response) ([]byte, error) {


### PR DESCRIPTION
## Summary

- A single transient network error or 5xx response previously failed the Step Functions step immediately with no recovery
- `SendRequest` now retries up to 3 times (1s then 2s backoff) on connection errors or HTTP 5xx responses
- Request body is reset between retries via `req.GetBody` (auto-populated by `http.NewRequest` for `*bytes.Buffer` / `*bytes.Reader` bodies)
- Context cancellation is respected during backoff — if the Lambda context deadline is reached mid-wait, the retry loop exits cleanly
- 4xx responses are passed through immediately (not retried) since they indicate a client error

## Changes

- `internal/platform/http/service/httpservice.go`: replaced single `client.Do` call with a retry loop in `SendRequest`

Closes #76