### PR TITLE
security: add logging and throttling to API Gateway callback endpoint

### DIFF
--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -277,8 +277,31 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 
 	// --- API Gateway ---
 
+	apiLogGroup := awslogs.NewLogGroup(stack, jsii.String("ApprovalCallbackApiLogGroup"), &awslogs.LogGroupProps{
+		LogGroupName:  jsii.String("/aws/apigateway/approval-callback-api" + suffix),
+		Retention:     awslogs.RetentionDays_THREE_MONTHS,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+	})
+
 	api := awsapigateway.NewRestApi(stack, jsii.String("ApprovalCallbackApi"), &awsapigateway.RestApiProps{
 		RestApiName: jsii.String("approval-callback-api" + suffix),
+		DeployOptions: &awsapigateway.StageOptions{
+			AccessLogDestination: awsapigateway.NewLogGroupLogDestination(apiLogGroup),
+			AccessLogFormat: awsapigateway.AccessLogFormat_JsonWithStandardFields(&awsapigateway.JsonWithStandardFieldProps{
+				Caller:         jsii.Bool(true),
+				HttpMethod:     jsii.Bool(true),
+				Ip:             jsii.Bool(true),
+				Protocol:       jsii.Bool(true),
+				RequestTime:    jsii.Bool(true),
+				ResourcePath:   jsii.Bool(true),
+				ResponseLength: jsii.Bool(true),
+				Status:         jsii.Bool(true),
+				User:           jsii.Bool(true),
+			}),
+			LoggingLevel:         awsapigateway.MethodLoggingLevel_ERROR,
+			ThrottlingBurstLimit: jsii.Number(10),
+			ThrottlingRateLimit:  jsii.Number(5),
+		},
 	})
 
 	callbackResource := api.Root().AddResource(jsii.String("callback"), nil)


### PR DESCRIPTION
## Summary
Adds JSON access logging and rate throttling to the `/callback` API Gateway stage to provide an audit trail and prevent abuse of the approval endpoint.

## Changes
- Create CloudWatch log group `/aws/apigateway/approval-callback-api` with 3-month retention
- Enable JSON access logging (IP, caller, HTTP method, status, request time, resource path, response length)
- Set execution logging level to ERROR
- Set stage throttling: 5 req/s rate limit, 10 req/s burst limit

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)