### PR TITLE
ops: add DLQ to SNS→SESForwarder subscription to catch failed deliveries

### DIFF
--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -355,7 +355,15 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		Resources: jsii.Strings(ssmArn),
 	}))
 
-	topic.AddSubscription(awssnssubscriptions.NewLambdaSubscription(sesForwarderFn, nil))
+	sesForwarderDLQ := awssqs.NewQueue(stack, jsii.String("SESForwarderDLQ"), &awssqs.QueueProps{
+		QueueName:       jsii.String("ses-forwarder-dlq" + suffix),
+		RetentionPeriod: awscdk.Duration_Days(jsii.Number(14)),
+		RemovalPolicy:   awscdk.RemovalPolicy_DESTROY,
+	})
+
+	topic.AddSubscription(awssnssubscriptions.NewLambdaSubscription(sesForwarderFn, &awssnssubscriptions.LambdaSubscriptionProps{
+		DeadLetterQueue: sesForwarderDLQ,
+	}))
 
 	// --- Step Functions State Machine ---
 


### PR DESCRIPTION
## Summary
Adds an SQS dead-letter queue to the SNS→SESForwarder Lambda subscription so failed deliveries are captured and can be replayed rather than silently dropped after SNS retries.

## Changes
- Create `ses-forwarder-dlq` SQS queue with 14-day message retention
- Wire it as `DeadLetterQueue` on the `NewLambdaSubscription` for SESForwarder

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)