### PR TITLE
ops: add error reporting to SESForwarder and ApprovalCallback lambdas

### DIFF
--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -283,6 +283,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		Actions:   jsii.Strings("states:SendTaskSuccess", "states:SendTaskFailure"),
 		Resources: jsii.Strings(stateMachineArn),
 	}))
+	topic.GrantPublish(approvalCallbackFn)
 
 	// --- API Gateway ---
 
@@ -364,6 +365,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	topic.AddSubscription(awssnssubscriptions.NewLambdaSubscription(sesForwarderFn, &awssnssubscriptions.LambdaSubscriptionProps{
 		DeadLetterQueue: sesForwarderDLQ,
 	}))
+	topic.GrantPublish(sesForwarderFn)
 
 	// --- Step Functions State Machine ---
 

--- a/internal/app/approvalcallback/config.go
+++ b/internal/app/approvalcallback/config.go
@@ -10,5 +10,8 @@ type Config struct {
 		SF struct {
 			ApprovalSecret string `mapstructure:"approvalSecret"`
 		} `mapstructure:"sf"`
+		SNS struct {
+			TopicArn string `mapstructure:"topicArn"`
+		} `mapstructure:"sns"`
 	} `mapstructure:"aws"`
 }

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -11,16 +11,33 @@ import (
 
 	ac "github.com/Bouzomgi/nycares-project-welcomer/internal/app/approvalcallback"
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/config"
+	"github.com/Bouzomgi/nycares-project-welcomer/internal/email"
+	snsservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/sns"
 	"github.com/aws/aws-lambda-go/events"
 )
 
 type ApprovalCallbackHandler struct {
 	usecase *ac.ApprovalCallbackUseCase
 	cfg     *ac.Config
+	snsSvc  snsservice.NotificationService
 }
 
-func NewApprovalCallbackHandler(u *ac.ApprovalCallbackUseCase, cfg *ac.Config) *ApprovalCallbackHandler {
-	return &ApprovalCallbackHandler{usecase: u, cfg: cfg}
+func NewApprovalCallbackHandler(u *ac.ApprovalCallbackUseCase, cfg *ac.Config, snsSvc snsservice.NotificationService) *ApprovalCallbackHandler {
+	return &ApprovalCallbackHandler{usecase: u, cfg: cfg, snsSvc: snsSvc}
+}
+
+func (h *ApprovalCallbackHandler) publishError(err error) {
+	if h.snsSvc == nil {
+		return
+	}
+	subject, plainText, htmlBody, renderErr := email.WorkflowFailed("ApprovalCallback", err.Error())
+	if renderErr != nil {
+		slog.Error("approvalcallback failed to render error notification", "error", renderErr)
+		return
+	}
+	if _, publishErr := h.snsSvc.PublishHTMLEmailNotification(context.Background(), plainText, htmlBody, subject); publishErr != nil {
+		slog.Error("approvalcallback failed to publish error notification", "error", publishErr)
+	}
 }
 
 func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
@@ -77,6 +94,7 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 	err := h.usecase.Execute(ctx, token, action, refinementContext)
 	if err != nil {
 		slog.Error("approvalcallback failed", "error", err)
+		h.publishError(err)
 		return events.APIGatewayProxyResponse{
 			StatusCode: 500,
 			Headers:    map[string]string{"Content-Type": "text/html"},

--- a/lambda/approvalcallback/main.go
+++ b/lambda/approvalcallback/main.go
@@ -9,9 +9,11 @@ import (
 	ac "github.com/Bouzomgi/nycares-project-welcomer/internal/app/approvalcallback"
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/config"
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/platform/awsconfig"
+	snsservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/sns"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 )
 
 func buildHandler() (*ApprovalCallbackHandler, error) {
@@ -27,9 +29,11 @@ func buildHandler() (*ApprovalCallbackHandler, error) {
 	}
 
 	sfnClient := sfn.NewFromConfig(awsCfg)
+	snsClient := sns.NewFromConfig(awsCfg)
+	snsSvc := snsservice.NewSNSService(snsClient, cfg.AWS.SNS.TopicArn)
 
 	usecase := ac.NewApprovalCallbackUseCase(sfnClient)
-	return NewApprovalCallbackHandler(usecase, cfg), nil
+	return NewApprovalCallbackHandler(usecase, cfg, snsSvc), nil
 }
 
 func main() {

--- a/lambda/sesforwarder/config.go
+++ b/lambda/sesforwarder/config.go
@@ -6,5 +6,8 @@ type Config struct {
 			Sender    string `mapstructure:"sender"`
 			Recipient string `mapstructure:"recipient"`
 		} `mapstructure:"ses"`
+		SNS struct {
+			TopicArn string `mapstructure:"topicArn"`
+		} `mapstructure:"sns"`
 	} `mapstructure:"aws"`
 }

--- a/lambda/sesforwarder/handler.go
+++ b/lambda/sesforwarder/handler.go
@@ -5,21 +5,38 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"github.com/Bouzomgi/nycares-project-welcomer/internal/email"
 	sesservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/ses"
+	snsservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/sns"
 	"github.com/aws/aws-lambda-go/events"
 )
 
 type SESForwarderHandler struct {
 	sesSvc *sesservice.SESService
+	snsSvc snsservice.NotificationService
 }
 
-func NewSESForwarderHandler(sesSvc *sesservice.SESService) *SESForwarderHandler {
-	return &SESForwarderHandler{sesSvc: sesSvc}
+func NewSESForwarderHandler(sesSvc *sesservice.SESService, snsSvc snsservice.NotificationService) *SESForwarderHandler {
+	return &SESForwarderHandler{sesSvc: sesSvc, snsSvc: snsSvc}
 }
 
 type htmlPayload struct {
 	HTMLBody  string `json:"htmlBody"`
 	PlainText string `json:"plainText"`
+}
+
+func (h *SESForwarderHandler) publishError(err error) {
+	if h.snsSvc == nil {
+		return
+	}
+	subject, plainText, htmlBody, renderErr := email.WorkflowFailed("SESForwarder", err.Error())
+	if renderErr != nil {
+		slog.Error("sesforwarder failed to render error notification", "error", renderErr)
+		return
+	}
+	if _, publishErr := h.snsSvc.PublishHTMLEmailNotification(context.Background(), plainText, htmlBody, subject); publishErr != nil {
+		slog.Error("sesforwarder failed to publish error notification", "error", publishErr)
+	}
 }
 
 func (h *SESForwarderHandler) Handle(ctx context.Context, event events.SNSEvent) error {
@@ -36,15 +53,18 @@ func (h *SESForwarderHandler) Handle(ctx context.Context, event events.SNSEvent)
 			var payload htmlPayload
 			if err := json.Unmarshal([]byte(msg.Message), &payload); err != nil {
 				slog.Error("sesforwarder failed to parse HTML payload", "error", err)
+				h.publishError(err)
 				return err
 			}
 			if err := h.sesSvc.SendHTMLEmail(ctx, subject, payload.HTMLBody, payload.PlainText); err != nil {
 				slog.Error("sesforwarder failed to send HTML email", "error", err)
+				h.publishError(err)
 				return err
 			}
 		} else {
 			if err := h.sesSvc.SendPlainEmail(ctx, subject, msg.Message); err != nil {
 				slog.Error("sesforwarder failed to send plain email", "error", err)
+				h.publishError(err)
 				return err
 			}
 		}

--- a/lambda/sesforwarder/main.go
+++ b/lambda/sesforwarder/main.go
@@ -7,9 +7,11 @@ import (
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/config"
 	"github.com/Bouzomgi/nycares-project-welcomer/internal/platform/awsconfig"
 	sesservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/ses"
+	snsservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/sns"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 )
 
 func buildHandler() (*SESForwarderHandler, error) {
@@ -27,7 +29,10 @@ func buildHandler() (*SESForwarderHandler, error) {
 	sesClient := sesv2.NewFromConfig(awsCfg)
 	sesSvc := sesservice.NewSESService(sesClient, cfg.AWS.SES.Sender, cfg.AWS.SES.Recipient)
 
-	return NewSESForwarderHandler(sesSvc), nil
+	snsClient := sns.NewFromConfig(awsCfg)
+	snsSvc := snsservice.NewSNSService(snsClient, cfg.AWS.SNS.TopicArn)
+
+	return NewSESForwarderHandler(sesSvc, snsSvc), nil
 }
 
 func main() {


### PR DESCRIPTION
## Summary
Both lambdas publish to the SNS notifications topic on error so failures surface immediately rather than requiring manual log inspection.

## Changes
- Add SNS topic ARN to `Config` for both `SESForwarder` and `ApprovalCallback`
- Wire `NotificationService` into each handler; publish via `email.WorkflowFailed` on error (best-effort — logs if publish fails)
- Grant `sns:Publish` on the notifications topic for both functions in CDK

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)