### PR TITLE
ops: handle approval timeout separately from other Step Functions errors

### DIFF
--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -192,6 +192,10 @@
             "Next": "CheckApprovalDecision",
             "Catch": [
               {
+                "ErrorEquals": ["States.TaskStateTimeout"],
+                "Next": "ApprovalTimedOut"
+              },
+              {
                 "ErrorEquals": ["States.ALL"],
                 "Next": "RequestApprovalToSendFailed"
               }
@@ -248,6 +252,15 @@
               "Error.$": "$.Error",
               "Cause.$": "$.Cause",
               "FailedStep": "RequestApprovalToSend"
+            },
+            "Next": "ProjectDLQNotifier"
+          },
+          "ApprovalTimedOut": {
+            "Type": "Pass",
+            "Parameters": {
+              "Error.$": "$.Error",
+              "Cause.$": "$.Cause",
+              "FailedStep": "RequestApprovalToSend (approval timed out — no response within 24 hours)"
             },
             "Next": "ProjectDLQNotifier"
           },


### PR DESCRIPTION
## Summary
`States.TaskStateTimeout` on `RequestApprovalToSend` was previously caught by `States.ALL`, making 24-hour approval timeouts indistinguishable from system errors or user rejections. Now it routes to a dedicated `ApprovalTimedOut` state with a clear label before notifying via `ProjectDLQNotifier`.

## Changes
- Add `States.TaskStateTimeout` catch before `States.ALL` in `RequestApprovalToSend`
- Add `ApprovalTimedOut` Pass state that sets `FailedStep` to a distinct timeout message and routes to `ProjectDLQNotifier`

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)