### PR TITLE
fix: handler context timeouts now account for Lambda remaining execution time

### DIFF
--- a/internal/config/timeout.go
+++ b/internal/config/timeout.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	// DefaultHandlerTimeout is the timeout for handlers that perform
@@ -16,3 +19,14 @@ const (
 	// services (e.g. Bedrock). Set below the Lambda function timeout (60s).
 	AIHandlerTimeout = 55 * time.Second
 )
+
+// HandlerDeadline returns a context capped at the earlier of the given timeout
+// and the Lambda context's remaining execution time, preventing the handler
+// from outlasting the Lambda's hard kill deadline.
+func HandlerDeadline(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	deadline := time.Now().Add(timeout)
+	if lambdaDeadline, ok := ctx.Deadline(); ok && lambdaDeadline.Before(deadline) {
+		deadline = lambdaDeadline
+	}
+	return context.WithDeadline(ctx, deadline)
+}

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -60,7 +60,7 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 
 	slog.Info("approvalcallback handler invoked", "action", getParam("action"))
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	// Validate shared secret if configured

--- a/lambda/computepreprojectmessage/handler.go
+++ b/lambda/computepreprojectmessage/handler.go
@@ -22,7 +22,7 @@ func NewComputeMessageHandler(u *cm.ComputeMessageUseCase, cfg *cm.Config) *Comp
 func (h *ComputeMessageHandler) Handle(ctx context.Context, input models.ComputeMessageInput) (models.ComputeMessageOutput, error) {
 	slog.Info("computepreprojectmessage handler invoked", "executionId", input.ExecutionId, "messageType", input.MessageType)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	messageType, err := domain.ParseNotificationType(input.MessageType)

--- a/lambda/dlqnotifier/handler.go
+++ b/lambda/dlqnotifier/handler.go
@@ -21,7 +21,7 @@ func NewDLQNotifierHandler(u *dlq.DLQNotifierUseCase, cfg *dlq.Config) *DLQNotif
 func (h *DLQNotifierHandler) Handle(ctx context.Context, input models.DLQNotifierInput) error {
 	slog.Error("dlqnotifier handler invoked", "error", input.Error, "cause", input.Cause)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	err := h.usecase.Execute(ctx, input)

--- a/lambda/fetchprojects/handler.go
+++ b/lambda/fetchprojects/handler.go
@@ -20,7 +20,7 @@ func NewFetchProjectsHandler(u *fp.FetchProjectsUseCase, cfg *fp.Config) *FetchP
 func (h *FetchProjectsHandler) Handle(ctx context.Context, input models.FetchProjectsInput) (models.FetchProjectsOutput, error) {
 	slog.Info("fetchprojects handler invoked", "executionId", input.ExecutionId)
 
-	ctx, cancel := context.WithTimeout(ctx, config.HTTPHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.HTTPHandlerTimeout)
 	defer cancel()
 
 	auth := models.ConvertAuth(input.Auth)

--- a/lambda/generatethankyoumessage/handler.go
+++ b/lambda/generatethankyoumessage/handler.go
@@ -21,7 +21,7 @@ func NewGenerateThankYouMessageHandler(u *gtm.GenerateThankYouMessageUseCase, cf
 func (h *GenerateThankYouMessageHandler) Handle(ctx context.Context, input models.GenerateThankYouMessageInput) (models.GenerateThankYouMessageOutput, error) {
 	slog.Info("generatethankyoumessage handler invoked", "executionId", input.ExecutionId, "project", input.ExistingProjectNotification.Name)
 
-	ctx, cancel := context.WithTimeout(ctx, config.AIHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.AIHandlerTimeout)
 	defer cancel()
 
 	generatedContent, err := h.usecase.Execute(ctx, input.ExistingProjectNotification.Name, input.RefinementContext)

--- a/lambda/login/handler.go
+++ b/lambda/login/handler.go
@@ -40,7 +40,7 @@ func (h *LoginHandler) Handle(ctx context.Context, input models.LoginInput) (mod
 		MockProjectsJSON: execInput.MockProjects,
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, config.HTTPHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.HTTPHandlerTimeout)
 	defer cancel()
 
 	authResp, err := h.usecase.Execute(ctx, creds)

--- a/lambda/notifycompletion/handler.go
+++ b/lambda/notifycompletion/handler.go
@@ -22,7 +22,7 @@ func NewNotifyCompletionHandler(u *nc.NotifyCompletionUseCase, cfg *nc.Config) *
 func (h *NotifyCompletionHandler) Handle(ctx context.Context, input models.NotifyCompletionInput) error {
 	slog.Info("notifycompletion handler invoked", "executionId", input.ExecutionId)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	domainProject, err := models.ConvertProjectNotificationToDomainProject(input.ExistingProjectNotification)

--- a/lambda/recordmessage/handler.go
+++ b/lambda/recordmessage/handler.go
@@ -22,7 +22,7 @@ func NewRecordMessageHandler(u *rm.RecordMessageUseCase, cfg *rm.Config) *Record
 func (h *RecordMessageHandler) Handle(ctx context.Context, input models.RecordMessageInput) (models.RecordMessageOutput, error) {
 	slog.Info("recordmessage handler invoked", "executionId", input.ExecutionId)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	domainProjectNotification, err := models.ConvertModelProjectNotification(input.ExistingProjectNotification)

--- a/lambda/requestapprovaltosend/handler.go
+++ b/lambda/requestapprovaltosend/handler.go
@@ -23,7 +23,7 @@ func NewRequestApprovalHandler(u *ra.RequestApprovalUseCase, cfg *ra.Config) *Re
 func (h *RequestApprovalHandler) Handle(ctx context.Context, input models.RequestApprovalInput) (models.RequestApprovalOutput, error) {
 	slog.Info("requestapproval handler invoked", "executionId", input.ExecutionId, "mockSendMessage", h.cfg.Mock.SendMessage)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	callbackEndpoint, err := url.Parse(h.cfg.AWS.SF.CallbackEndpoint)

--- a/lambda/routeproject/handler.go
+++ b/lambda/routeproject/handler.go
@@ -22,7 +22,7 @@ func NewRouteProjectHandler(u *rp.RouteProjectUseCase, cfg *rp.Config) *RoutePro
 func (h *RouteProjectHandler) Handle(ctx context.Context, input models.RouteProjectInput) (models.RouteProjectOutput, error) {
 	slog.Info("routeproject handler invoked", "executionId", input.ExecutionId)
 
-	ctx, cancel := context.WithTimeout(ctx, config.DefaultHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.DefaultHandlerTimeout)
 	defer cancel()
 
 	domainProject, err := models.BuildDomainProject(input.Project)

--- a/lambda/sendandpinmessage/handler.go
+++ b/lambda/sendandpinmessage/handler.go
@@ -21,7 +21,7 @@ func NewSendAndPinMessageHandler(u *spm.SendAndPinMessageUseCase, cfg *spm.Confi
 func (h *SendAndPinMessageHandler) Handle(ctx context.Context, input models.SendAndPinMessageInput) (models.SendAndPinMessageOutput, error) {
 	slog.Info("sendandpinmessage handler invoked", "executionId", input.ExecutionId, "projectId", input.ExistingProjectNotification.Id)
 
-	ctx, cancel := context.WithTimeout(ctx, config.HTTPHandlerTimeout)
+	ctx, cancel := config.HandlerDeadline(ctx, config.HTTPHandlerTimeout)
 	defer cancel()
 
 	auth := models.ConvertAuth(input.Auth)


### PR DESCRIPTION
## Summary
Handler timeouts previously used a fixed duration from `time.Now()`, which could outlast Lambda's actual remaining execution time if initialization consumed several seconds. Handlers now cap at the Lambda context's hard-kill deadline.

## Changes
- Add `config.HandlerDeadline(ctx, timeout)` helper that takes the minimum of the configured timeout and the Lambda context deadline
- Replace `context.WithTimeout(ctx, config.XxxHandlerTimeout)` with `config.HandlerDeadline(ctx, config.XxxHandlerTimeout)` in all 11 handler files

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)