### PR TITLE
fix: toKebabCase handles hyphens, underscores, and special characters

### DIFF
--- a/internal/app/generatethankyoumessage/usecase.go
+++ b/internal/app/generatethankyoumessage/usecase.go
@@ -3,11 +3,14 @@ package generatethankyoumessage
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	bedrockservice "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/bedrock"
 	s3service "github.com/Bouzomgi/nycares-project-welcomer/internal/platform/s3"
 )
+
+var nonAlphanumeric = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 type GenerateThankYouMessageUseCase struct {
 	s3Service      s3service.ContentService
@@ -35,12 +38,12 @@ func (u *GenerateThankYouMessageUseCase) Execute(ctx context.Context, projectNam
 }
 
 func toKebabCase(s string) string {
-	words := strings.Fields(s)
-	if len(words) == 0 {
-		return ""
-	}
-	for i := range words {
-		words[i] = strings.ToLower(words[i])
+	parts := nonAlphanumeric.Split(s, -1)
+	words := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			words = append(words, strings.ToLower(p))
+		}
 	}
 	return strings.Join(words, "-")
 }

--- a/internal/app/generatethankyoumessage/usecase_test.go
+++ b/internal/app/generatethankyoumessage/usecase_test.go
@@ -1,0 +1,29 @@
+package generatethankyoumessage
+
+import (
+	"testing"
+)
+
+func TestToKebabCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Central Park Cleanup", "central-park-cleanup"},
+		{"after-school tutoring", "after-school-tutoring"},
+		{"food_bank_sort", "food-bank-sort"},
+		{"Meals on Wheels!", "meals-on-wheels"},
+		{"NYC---Cares Event", "nyc-cares-event"},
+		{"  leading spaces  ", "leading-spaces"},
+		{"", ""},
+		{"single", "single"},
+		{"Already-Kebab", "already-kebab"},
+	}
+
+	for _, tt := range tests {
+		got := toKebabCase(tt.input)
+		if got != tt.expected {
+			t.Errorf("toKebabCase(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
`toKebabCase` used `strings.Fields` which only splits on whitespace, producing incorrect S3 key segments for project names with hyphens, underscores, or punctuation.

## Changes
- Replace `strings.Fields` split with `regexp.MustCompile("[^a-zA-Z0-9]+").Split` to handle any non-alphanumeric separator
- Add `usecase_test.go` with cases covering whitespace, hyphens, underscores, punctuation, leading/trailing separators, and empty input

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)