### PR TITLE
refactor: simplify Bedrock prompt to single message and improve project name phrasing

### DIFF
--- a/internal/app/generatethankyoumessage/usecase.go
+++ b/internal/app/generatethankyoumessage/usecase.go
@@ -34,7 +34,7 @@ func (u *GenerateThankYouMessageUseCase) Execute(ctx context.Context, projectNam
 		return "", fmt.Errorf("failed to fetch writing samples: %w", err)
 	}
 
-	return u.bedrockService.GenerateThankYouMessage(ctx, writingSample, projectName, refinementContext)
+	return u.bedrockService.GenerateThankYouMessage(ctx, writingSample, refinementContext)
 }
 
 func toKebabCase(s string) string {

--- a/internal/platform/bedrock/bedrockservice.go
+++ b/internal/platform/bedrock/bedrockservice.go
@@ -25,7 +25,7 @@ func NewBedrockService(client *bedrockruntime.Client) *BedrockService {
 
 func (s *BedrockService) GenerateThankYouMessage(ctx context.Context, writingSample, refinementContext string) (string, error) {
 	prompt := fmt.Sprintf(
-		"You are writing thank-you messages on behalf of a volunteer program coordinator. Here are several example messages they have written — match their style exactly:\n\n%s\n\nWrite a new, unique thank-you message (2-3 sentences) for a team leader who led today's volunteer project. Match the style of the examples but do not repeat any of them.",
+		"You are a volunteer project team leader writing thank-you messages to your volunteers. Here are several example messages you have written — match their style exactly:\n\n%s\n\nWrite a new, unique thank-you message (2-3 sentences) to the volunteers who helped with today's project. Match the style of the examples but do not repeat any of them.",
 		writingSample,
 	)
 	if refinementContext != "" {

--- a/internal/platform/bedrock/bedrockservice.go
+++ b/internal/platform/bedrock/bedrockservice.go
@@ -12,7 +12,7 @@ import (
 const ModelID = "us.amazon.nova-lite-v1:0"
 
 type GenerationService interface {
-	GenerateThankYouMessage(ctx context.Context, writingSample, projectName, refinementContext string) (string, error)
+	GenerateThankYouMessage(ctx context.Context, writingSample, refinementContext string) (string, error)
 }
 
 type BedrockService struct {
@@ -23,23 +23,22 @@ func NewBedrockService(client *bedrockruntime.Client) *BedrockService {
 	return &BedrockService{client: client}
 }
 
-func (s *BedrockService) GenerateThankYouMessage(ctx context.Context, writingSample, projectName, refinementContext string) (string, error) {
-	systemPrompt := fmt.Sprintf("You are writing thank-you messages on behalf of a volunteer program coordinator. Here are several example messages they have written — match their style exactly:\n\n%s", writingSample)
-	userPrompt := fmt.Sprintf("Write a new, unique thank-you message (2-3 sentences) for a team leader who led the volunteer project \"%s\" today. Match the style of the examples but do not repeat any of them.", projectName)
+func (s *BedrockService) GenerateThankYouMessage(ctx context.Context, writingSample, refinementContext string) (string, error) {
+	prompt := fmt.Sprintf(
+		"You are writing thank-you messages on behalf of a volunteer program coordinator. Here are several example messages they have written — match their style exactly:\n\n%s\n\nWrite a new, unique thank-you message (2-3 sentences) for a team leader who led today's volunteer project. Match the style of the examples but do not repeat any of them.",
+		writingSample,
+	)
 	if refinementContext != "" {
-		userPrompt += fmt.Sprintf(" Additional context to incorporate: %s", refinementContext)
+		prompt += fmt.Sprintf(" Additional context to incorporate: %s", refinementContext)
 	}
 
 	resp, err := s.client.Converse(ctx, &bedrockruntime.ConverseInput{
 		ModelId: aws.String(ModelID),
-		System: []types.SystemContentBlock{
-			&types.SystemContentBlockMemberText{Value: systemPrompt},
-		},
 		Messages: []types.Message{
 			{
 				Role: types.ConversationRoleUser,
 				Content: []types.ContentBlock{
-					&types.ContentBlockMemberText{Value: userPrompt},
+					&types.ContentBlockMemberText{Value: prompt},
 				},
 			},
 		},

--- a/internal/platform/bedrock/mockbedrockservice.go
+++ b/internal/platform/bedrock/mockbedrockservice.go
@@ -1,9 +1,6 @@
 package bedrockservice
 
-import (
-	"context"
-	"fmt"
-)
+import "context"
 
 type MockBedrockService struct{}
 
@@ -11,6 +8,6 @@ func NewMockBedrockService() *MockBedrockService {
 	return &MockBedrockService{}
 }
 
-func (s *MockBedrockService) GenerateThankYouMessage(_ context.Context, _, projectName, _ string) (string, error) {
-	return fmt.Sprintf("Thank you so much for leading \"%s\" today — your dedication makes a real difference!", projectName), nil
+func (s *MockBedrockService) GenerateThankYouMessage(_ context.Context, _, _ string) (string, error) {
+	return "Thank you so much for leading today's volunteer project — your dedication makes a real difference!", nil
 }

--- a/internal/platform/bedrock/mockbedrockservice.go
+++ b/internal/platform/bedrock/mockbedrockservice.go
@@ -9,5 +9,5 @@ func NewMockBedrockService() *MockBedrockService {
 }
 
 func (s *MockBedrockService) GenerateThankYouMessage(_ context.Context, _, _ string) (string, error) {
-	return "Thank you so much for leading today's volunteer project — your dedication makes a real difference!", nil
+	return "Thank you so much for your help today — your dedication makes a real difference!", nil
 }


### PR DESCRIPTION
## Summary

- Collapses the system + user prompt split in `GenerateThankYouMessage` into a single user message — simpler and equivalent for single-turn generation
- Replaces `led the volunteer project "{{projectName}}"` with `led today's volunteer project` for more natural phrasing
- Removes the now-unused `projectName` parameter from the `GenerationService` interface, `BedrockService`, `MockBedrockService`, and the usecase call site

## Changes

- `internal/platform/bedrock/bedrockservice.go` — merged system+user prompts; dropped `projectName` param
- `internal/platform/bedrock/mockbedrockservice.go` — updated mock signature and response to match
- `internal/app/generatethankyoumessage/usecase.go` — removed `projectName` from `GenerateThankYouMessage` call

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)