### PR TITLE
feat: add manual message option to thank-you approval flow

### DIFF
--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -213,9 +213,28 @@
                 "Variable": "$.approvalResult.action",
                 "StringEquals": "reject",
                 "Next": "EndProjectIteration"
+              },
+              {
+                "Variable": "$.approvalResult.action",
+                "StringEquals": "manual",
+                "Next": "UseManualMessage"
               }
             ],
             "Default": "RegenerateThankYouMessage"
+          },
+          "UseManualMessage": {
+            "Type": "Pass",
+            "Parameters": {
+              "auth.$": "$.auth",
+              "existingProjectNotification.$": "$.existingProjectNotification",
+              "message": {
+                "type.$": "$.message.type",
+                "templateRef.$": "$.message.templateRef",
+                "generatedContent.$": "$.approvalResult.manualMessage"
+              },
+              "executionId.$": "$.executionId"
+            },
+            "Next": "SendAndPinMessage"
           },
           "RegenerateThankYouMessage": {
             "Type": "Task",

--- a/internal/app/approvalcallback/usecase.go
+++ b/internal/app/approvalcallback/usecase.go
@@ -25,20 +25,23 @@ func NewApprovalCallbackUseCase(sfnClient SFNClient) *ApprovalCallbackUseCase {
 //   - "regenerate"  → SendTaskSuccess with action="regenerate" (fresh generation, no context)
 //   - "refine"      → SendTaskSuccess with action="refine" and the supplied refinementContext
 //   - "reject"      → SendTaskSuccess with action="reject" (routes to EndProjectIteration, not DLQ)
-func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action, refinementContext string) error {
+//   - "manual"      → SendTaskSuccess with action="manual" and the supplied manualMessage
+func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action, refinementContext, manualMessage string) error {
 	if taskToken == "" {
 		return fmt.Errorf("taskToken must be defined")
 	}
 
 	switch action {
-	case "approve", "regenerate", "refine", "reject":
+	case "approve", "regenerate", "refine", "reject", "manual":
 		type successOutput struct {
 			Action            string `json:"action"`
 			RefinementContext string `json:"refinementContext"`
+			ManualMessage     string `json:"manualMessage"`
 		}
 		out, err := json.Marshal(successOutput{
 			Action:            action,
 			RefinementContext: refinementContext,
+			ManualMessage:     manualMessage,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to marshal task output: %w", err)
@@ -51,6 +54,6 @@ func (u *ApprovalCallbackUseCase) Execute(ctx context.Context, taskToken, action
 		return err
 
 	default:
-		return fmt.Errorf("unknown action %q: must be approve, regenerate, refine, or reject", action)
+		return fmt.Errorf("unknown action %q: must be approve, regenerate, refine, reject, or manual", action)
 	}
 }

--- a/internal/email/templates/approval_request.html
+++ b/internal/email/templates/approval_request.html
@@ -30,6 +30,13 @@
   <textarea name="context" rows="3" cols="60" placeholder="e.g. it was raining today"></textarea><br>
   <input type="submit" value="Refine &amp; Regenerate">
 </form>
+<p><strong>Write your own message:</strong></p>
+<form method="post" action="{{.RefineFormBase}}">
+  {{if .Secret}}<input type="hidden" name="secret" value="{{.Secret}}">{{end}}
+  <input type="hidden" name="action" value="manual">
+  <textarea name="manualMessage" rows="5" cols="60" placeholder="Write your thank-you message here..."></textarea><br>
+  <input type="submit" value="Send My Message">
+</form>
 {{else}}
 <p>
   <form method="post" action="{{.ApproveLink}}" style="display:inline">

--- a/lambda/approvalcallback/handler.go
+++ b/lambda/approvalcallback/handler.go
@@ -82,6 +82,10 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 	if len(refinementContext) > 500 {
 		refinementContext = refinementContext[:500]
 	}
+	manualMessage := getParam("manualMessage")
+	if len(manualMessage) > 2000 {
+		manualMessage = manualMessage[:2000]
+	}
 
 	if token == "" || action == "" {
 		return events.APIGatewayProxyResponse{
@@ -91,7 +95,15 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		}, nil
 	}
 
-	err := h.usecase.Execute(ctx, token, action, refinementContext)
+	if action == "manual" && manualMessage == "" {
+		return events.APIGatewayProxyResponse{
+			StatusCode: 400,
+			Headers:    map[string]string{"Content-Type": "text/html"},
+			Body:       "<html><body><h1>Bad Request</h1><p>manualMessage is required for action=manual.</p></body></html>",
+		}, nil
+	}
+
+	err := h.usecase.Execute(ctx, token, action, refinementContext, manualMessage)
 	if err != nil {
 		slog.Error("approvalcallback failed", "error", err)
 		h.publishError(err)
@@ -114,6 +126,8 @@ func (h *ApprovalCallbackHandler) Handle(ctx context.Context, request events.API
 		message = "Regenerating with your context. A new approval email will arrive shortly."
 	case "reject":
 		message = "Rejected. The message will not be sent."
+	case "manual":
+		message = "Your message will be sent shortly."
 	default:
 		message = fmt.Sprintf("Action %q processed.", action)
 	}


### PR DESCRIPTION
## Summary

- Adds a **"Write your own message"** form to the thank-you approval email
- Submitting it sends `action=manual` with the written text, bypassing `GenerateThankYouMessage` and Bedrock entirely
- A new `UseManualMessage` Pass state in Step Functions copies the manual text into `$.message.generatedContent` before routing to `SendAndPinMessage`
- Manual message is capped at 2000 characters; missing message returns 400

## Changes

- `internal/app/approvalcallback/usecase.go` — adds `manual` action and `ManualMessage` field to task output
- `lambda/approvalcallback/handler.go` — reads `manualMessage` param, validates it for `action=manual`, passes to usecase
- `internal/email/templates/approval_request.html` — adds "Write your own message" form in the thankYou section
- `infra/DailyProjectNotificationWorkflow.json` — adds `UseManualMessage` Pass state and `manual` branch in `CheckApprovalDecision`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)