### PR TITLE
fix: remove States.TaskStateTimeout catch to unblock LocalStack deploy

### DIFF
--- a/infra/DailyProjectNotificationWorkflow.json
+++ b/infra/DailyProjectNotificationWorkflow.json
@@ -192,12 +192,8 @@
             "Next": "CheckApprovalDecision",
             "Catch": [
               {
-                "ErrorEquals": ["States.TaskStateTimeout"],
-                "Next": "ApprovalTimedOut"
-              },
-              {
                 "ErrorEquals": ["States.ALL"],
-                "Next": "RequestApprovalToSendFailed"
+                "Next": "ApprovalTimedOut"
               }
             ]
           },
@@ -265,21 +261,12 @@
             },
             "Next": "ProjectDLQNotifier"
           },
-          "RequestApprovalToSendFailed": {
-            "Type": "Pass",
-            "Parameters": {
-              "Error.$": "$.Error",
-              "Cause.$": "$.Cause",
-              "FailedStep": "RequestApprovalToSend"
-            },
-            "Next": "ProjectDLQNotifier"
-          },
           "ApprovalTimedOut": {
             "Type": "Pass",
             "Parameters": {
               "Error.$": "$.Error",
               "Cause.$": "$.Cause",
-              "FailedStep": "RequestApprovalToSend (approval timed out — no response within 24 hours)"
+              "FailedStep": "RequestApprovalToSend (timed out or failed)"
             },
             "Next": "ProjectDLQNotifier"
           },


### PR DESCRIPTION
## Summary

- LocalStack 4.14.0 incorrectly rejects `States.TaskStateTimeout` as a custom error name, blocking `docker compose up deploy-cdk`
- Consolidates the two `RequestApprovalToSend` catches into a single `States.ALL` → `ApprovalTimedOut` catch
- Removes the now-dead `RequestApprovalToSendFailed` state

The tradeoff is that all failures on this step (not just timeouts) will now show "timed out or failed" in the DLQ notification. Real AWS behavior is unchanged — `States.ALL` catches timeouts too.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)