### PR TITLE
fix: seed SSM parameters in LocalStack to unblock local e2e tests

### DIFF
--- a/seed/seed_localstack.sh
+++ b/seed/seed_localstack.sh
@@ -30,4 +30,24 @@ FILES_DIR="${S3_FILES_DIR:-/seed/s3Items}"
 echo "Syncing $FILES_DIR to s3://$BUCKET..."
 aws_cmd s3 sync "$FILES_DIR" "s3://$BUCKET" --exclude "*.txt"
 
+if [ -n "${AWS_ENDPOINT_URL:-}" ]; then
+  echo "Seeding SSM parameters..."
+  SSM_PATH="/nycares-project-welcomer"
+  for KEY_VAL in \
+    "NYCARES_ACCOUNT_USERNAME:${NYCARES_ACCOUNT_USERNAME:-user}" \
+    "NYCARES_ACCOUNT_PASSWORD:${NYCARES_ACCOUNT_PASSWORD:-pass}" \
+    "NYCARES_AWS_SF_CALLBACKENDPOINT:${NYCARES_AWS_SF_CALLBACKENDPOINT:-http://localhost:4566}" \
+    "NYCARES_AWS_SF_APPROVALSECRET:${NYCARES_AWS_SF_APPROVALSECRET:-test-secret}"
+  do
+    KEY="${KEY_VAL%%:*}"
+    VAL="${KEY_VAL#*:}"
+    aws_cmd ssm put-parameter \
+      --name "${SSM_PATH}/${KEY}" \
+      --value "$VAL" \
+      --type String \
+      --overwrite \
+      > /dev/null
+  done
+fi
+
 echo "LocalStack seed complete."


### PR DESCRIPTION
## Summary

- Lambdas were crashing with `exit status 2` on startup because `NYCARES_SSM_PATH` is set on every Lambda by CDK, causing them to fetch credentials from SSM — but LocalStack had no parameters seeded
- Adds four `aws ssm put-parameter` calls to `seed_localstack.sh` for the required parameters: account username/password, SF callback endpoint, and approval secret
- All 11 e2e scenarios now pass locally via `docker compose up && make e2e`

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)