### PR TITLE
refactor: standardize all NYC Cares references to nycares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,6 @@ jobs:
           aws ssm put-parameter --name "/nycares-project-welcomer/NYCARES_ACCOUNT_PASSWORD" --value "$NYCARES_ACCOUNT_PASSWORD" --type SecureString --overwrite
           aws ssm put-parameter --name "/nycares-project-welcomer/NYCARES_AWS_SF_APPROVALSECRET" --value "$NYCARES_AWS_SF_APPROVALSECRET" --type SecureString --overwrite
 
-      - name: Ensure S3 bucket exists
-        run: |
-          aws s3api head-bucket --bucket nycares-project-welcomer-messages-ci 2>/dev/null || \
-            aws s3api create-bucket --bucket nycares-project-welcomer-messages-ci --region us-east-1
-
       - name: Deploy test environment
         env:
           DEPLOY_MOCKSERVER: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
           aws ssm put-parameter --name "/nycares-project-welcomer/NYCARES_ACCOUNT_PASSWORD" --value "$NYCARES_ACCOUNT_PASSWORD" --type SecureString --overwrite
           aws ssm put-parameter --name "/nycares-project-welcomer/NYCARES_AWS_SF_APPROVALSECRET" --value "$NYCARES_AWS_SF_APPROVALSECRET" --type SecureString --overwrite
 
+      - name: Ensure S3 bucket exists
+        run: |
+          aws s3api head-bucket --bucket nycares-project-welcomer-messages-ci 2>/dev/null || \
+            aws s3api create-bucket --bucket nycares-project-welcomer-messages-ci --region us-east-1
+
       - name: Deploy test environment
         env:
           DEPLOY_MOCKSERVER: "true"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-NYC Cares Project Welcomer — a serverless notification system that sends welcome/reminder messages to New York Cares project attendees.
+nycares Project Welcomer — a serverless notification system that sends welcome/reminder messages to nycares project attendees.
 
 This is a Go/CDK project deployed to AWS. Primary languages: Go for Lambda functions, TypeScript for CDK infrastructure, YAML for CI/CD (GitHub Actions). Always consider deployment implications when making infrastructure changes.
 
@@ -34,7 +34,7 @@ cd infra && cdk deploy
 
 ### Run mock server (local dev)
 
-The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simulates the NYC Cares API. Used alongside LocalStack for local AWS services (S3, DynamoDB, SNS).
+The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simulates the nycares API. Used alongside LocalStack for local AWS services (S3, DynamoDB, SNS).
 
 ## Architecture
 
@@ -43,7 +43,7 @@ The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simul
 A Step Functions state machine orchestrates 11 Lambda functions. Two run once per execution at the top level; seven run per project inside a Map iterator:
 
 **Top-level (once per execution):**
-1. **Login** → authenticate with NYC Cares API
+1. **Login** → authenticate with nycares API
 2. **FetchProjects** → fetch upcoming and today's projects (merges `/upcoming` + `/today` endpoints, deduplicated by project ID)
 
 **Per-project (Map iterator):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-nycares Project Welcomer — a serverless notification system that sends welcome/reminder messages to nycares project attendees.
+NYCares Project Welcomer — a serverless notification system that sends welcome/reminder messages to NYCares project attendees.
 
 This is a Go/CDK project deployed to AWS. Primary languages: Go for Lambda functions, TypeScript for CDK infrastructure, YAML for CI/CD (GitHub Actions). Always consider deployment implications when making infrastructure changes.
 
@@ -34,7 +34,7 @@ cd infra && cdk deploy
 
 ### Run mock server (local dev)
 
-The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simulates the nycares API. Used alongside LocalStack for local AWS services (S3, DynamoDB, SNS).
+The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simulates the NYCares API. Used alongside LocalStack for local AWS services (S3, DynamoDB, SNS).
 
 ## Architecture
 
@@ -43,7 +43,7 @@ The mock server at [`internal/mockserver/`](internal/mockserver/CLAUDE.md) simul
 A Step Functions state machine orchestrates 11 Lambda functions. Two run once per execution at the top level; seven run per project inside a Map iterator:
 
 **Top-level (once per execution):**
-1. **Login** → authenticate with nycares API
+1. **Login** → authenticate with NYCares API
 2. **FetchProjects** → fetch upcoming and today's projects (merges `/upcoming` + `/today` endpoints, deduplicated by project ID)
 
 **Per-project (Map iterator):**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# nycares Project Welcomer
+# NYCares Project Welcomer
 
-A serverless notification system that sends welcome, reminder, and thank-you messages to nycares project attendees. Built with Go, AWS Lambda, and Step Functions.
+A serverless notification system that sends welcome, reminder, and thank-you messages to NYCares project attendees. Built with Go, AWS Lambda, and Step Functions.
 
 ## How It Works
 
@@ -74,7 +74,7 @@ Each project (identified by name + date) receives at most one of each message ty
 │   ├── platform/            # AWS service integrations (DynamoDB, S3, SNS, HTTP)
 │   ├── config/              # YAML/env var config loader
 │   ├── endpoints/           # API URL constants
-│   └── mockserver/          # Local mock of nycares API
+│   └── mockserver/          # Local mock of NYCares API
 ├── infra/                   # AWS CDK stack (Go)
 ├── e2e/                     # E2E tests (run against LocalStack)
 ├── seed/                    # S3 seed data for local dev
@@ -99,7 +99,7 @@ make up
 
 This spins up:
 - **LocalStack** — local AWS (DynamoDB, S3, SNS, Step Functions, Lambda, API Gateway)
-- **Mock server** — simulates the nycares API
+- **Mock server** — simulates the NYCares API
 - **CDK deploy** — provisions all infrastructure in LocalStack
 - **S3 seeding** — uploads message templates
 
@@ -133,7 +133,7 @@ Locally, config loads from `config.yaml`. In Lambda, environment variables with 
 | Variable                | Description                                    |
 |-------------------------|------------------------------------------------|
 | `NYCARES_CURRENT_DATE`  | Override current date (YYYY-MM-DD) for testing |
-| `NYCARES_API_BASE_URL`  | Override nycares API base URL                  |
+| `NYCARES_API_BASE_URL`  | Override NYCares API base URL                  |
 
 ## DynamoDB Schema
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NYC Cares Project Welcomer
+# nycares Project Welcomer
 
-A serverless notification system that sends welcome, reminder, and thank-you messages to New York Cares project attendees. Built with Go, AWS Lambda, and Step Functions.
+A serverless notification system that sends welcome, reminder, and thank-you messages to nycares project attendees. Built with Go, AWS Lambda, and Step Functions.
 
 ## How It Works
 
@@ -74,7 +74,7 @@ Each project (identified by name + date) receives at most one of each message ty
 │   ├── platform/            # AWS service integrations (DynamoDB, S3, SNS, HTTP)
 │   ├── config/              # YAML/env var config loader
 │   ├── endpoints/           # API URL constants
-│   └── mockserver/          # Local mock of NYC Cares API
+│   └── mockserver/          # Local mock of nycares API
 ├── infra/                   # AWS CDK stack (Go)
 ├── e2e/                     # E2E tests (run against LocalStack)
 ├── seed/                    # S3 seed data for local dev
@@ -99,7 +99,7 @@ make up
 
 This spins up:
 - **LocalStack** — local AWS (DynamoDB, S3, SNS, Step Functions, Lambda, API Gateway)
-- **Mock server** — simulates the NYC Cares API
+- **Mock server** — simulates the nycares API
 - **CDK deploy** — provisions all infrastructure in LocalStack
 - **S3 seeding** — uploads message templates
 
@@ -133,7 +133,7 @@ Locally, config loads from `config.yaml`. In Lambda, environment variables with 
 | Variable                | Description                                    |
 |-------------------------|------------------------------------------------|
 | `NYCARES_CURRENT_DATE`  | Override current date (YYYY-MM-DD) for testing |
-| `NYCARES_API_BASE_URL`  | Override NYC Cares API base URL                |
+| `NYCARES_API_BASE_URL`  | Override nycares API base URL                  |
 
 ## DynamoDB Schema
 

--- a/cmd/emailpreview/main.go
+++ b/cmd/emailpreview/main.go
@@ -34,7 +34,7 @@ func main() {
 
 		s, p, h, err := email.WorkflowFailed(
 			"SendAndPinMessage",
-			"connection to NYC Cares API timed out after 30s",
+			"connection to nycares API timed out after 30s",
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to render workflow-failed email: %v\n", err)

--- a/cmd/emailpreview/main.go
+++ b/cmd/emailpreview/main.go
@@ -34,7 +34,7 @@ func main() {
 
 		s, p, h, err := email.WorkflowFailed(
 			"SendAndPinMessage",
-			"connection to nycares API timed out after 30s",
+			"connection to NYCares API timed out after 30s",
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to render workflow-failed email: %v\n", err)

--- a/e2e/features/workflow.feature
+++ b/e2e/features/workflow.feature
@@ -1,5 +1,5 @@
 Feature: Project notification workflow
-  The system sends welcome and reminder messages to upcoming NYC Cares
+  The system sends welcome and reminder messages to upcoming nycares
   project attendees based on how far away the project date is.
 
   Background:

--- a/e2e/features/workflow.feature
+++ b/e2e/features/workflow.feature
@@ -1,5 +1,5 @@
 Feature: Project notification workflow
-  The system sends welcome and reminder messages to upcoming nycares
+  The system sends welcome and reminder messages to upcoming NYCares
   project attendees based on how far away the project date is.
 
   Background:

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -102,13 +102,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 			RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
 		})
 
-		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
-			BucketName:        jsii.String(bucketName),
-			RemovalPolicy:     awscdk.RemovalPolicy_RETAIN,
-			Versioned:         jsii.Bool(true),
-			Encryption:        awss3.BucketEncryption_S3_MANAGED,
-			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),
-		})
+		bucket = awss3.Bucket_FromBucketName(stack, jsii.String("MessageTemplates"), jsii.String(bucketName))
 
 	} else {
 		// Import pre-existing resources (LocalStack / production without suffix)

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -104,7 +104,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 
 		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
 			BucketName:        jsii.String(bucketName),
-			RemovalPolicy:     awscdk.RemovalPolicy_RETAIN,
+			RemovalPolicy:     awscdk.RemovalPolicy_DESTROY,
 			Versioned:         jsii.Bool(true),
 			Encryption:        awss3.BucketEncryption_S3_MANAGED,
 			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -161,7 +161,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	// When a mock server URL is provided AND this is an ephemeral environment (suffix != ""),
 	// override NYCARES_API_BASE_URL globally — integration tests mock the full API including
 	// Login and FetchProjects. In production (no suffix), only SendAndPinMessage should route
-	// to the mock server; Login/FetchProjects must hit the real NYC Cares API. The per-lambda
+	// to the mock server; Login/FetchProjects must hit the real nycares API. The per-lambda
 	// override for production is applied after the lambda loop below.
 	if props != nil && props.MockServerUrl != nil && suffix != "" {
 		(*sharedEnv)["NYCARES_API_BASE_URL"] = props.MockServerUrl
@@ -198,7 +198,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		case "GenerateThankYouMessage":
 			reservedConcurrency = jsii.Number(5) // Bedrock per-account invocation quota
 		case "SendAndPinMessage":
-			reservedConcurrency = jsii.Number(10) // NYC Cares API rate limit
+			reservedConcurrency = jsii.Number(10) // nycares API rate limit
 		}
 
 		fn := awslambda.NewFunction(stack, jsii.String(name), &awslambda.FunctionProps{
@@ -220,7 +220,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	}
 
 	// Production mock mode (no suffix): only SendAndPinMessage routes to the mock server.
-	// Login and FetchProjects continue hitting the real NYC Cares API so that real project
+	// Login and FetchProjects continue hitting the real nycares API so that real project
 	// data and auth cookies are used.
 	if props != nil && props.MockServerUrl != nil && suffix == "" {
 		lambdaFns["SendAndPinMessage"].AddEnvironment(

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -105,6 +105,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
 			BucketName:        jsii.String(bucketName),
 			RemovalPolicy:     awscdk.RemovalPolicy_DESTROY,
+			AutoDeleteObjects: jsii.Bool(true),
 			Versioned:         jsii.Bool(true),
 			Encryption:        awss3.BucketEncryption_S3_MANAGED,
 			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -161,7 +161,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	// When a mock server URL is provided AND this is an ephemeral environment (suffix != ""),
 	// override NYCARES_API_BASE_URL globally — integration tests mock the full API including
 	// Login and FetchProjects. In production (no suffix), only SendAndPinMessage should route
-	// to the mock server; Login/FetchProjects must hit the real nycares API. The per-lambda
+	// to the mock server; Login/FetchProjects must hit the real NYCares API. The per-lambda
 	// override for production is applied after the lambda loop below.
 	if props != nil && props.MockServerUrl != nil && suffix != "" {
 		(*sharedEnv)["NYCARES_API_BASE_URL"] = props.MockServerUrl
@@ -198,7 +198,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 		case "GenerateThankYouMessage":
 			reservedConcurrency = jsii.Number(5) // Bedrock per-account invocation quota
 		case "SendAndPinMessage":
-			reservedConcurrency = jsii.Number(10) // nycares API rate limit
+			reservedConcurrency = jsii.Number(10) // NYCares API rate limit
 		}
 
 		fn := awslambda.NewFunction(stack, jsii.String(name), &awslambda.FunctionProps{
@@ -220,7 +220,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 	}
 
 	// Production mock mode (no suffix): only SendAndPinMessage routes to the mock server.
-	// Login and FetchProjects continue hitting the real nycares API so that real project
+	// Login and FetchProjects continue hitting the real NYCares API so that real project
 	// data and auth cookies are used.
 	if props != nil && props.MockServerUrl != nil && suffix == "" {
 		lambdaFns["SendAndPinMessage"].AddEnvironment(

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -102,7 +102,13 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 			RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
 		})
 
-		bucket = awss3.Bucket_FromBucketName(stack, jsii.String("MessageTemplates"), jsii.String(bucketName))
+		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
+			BucketName:        jsii.String(bucketName),
+			RemovalPolicy:     awscdk.RemovalPolicy_RETAIN,
+			Versioned:         jsii.Bool(true),
+			Encryption:        awss3.BucketEncryption_S3_MANAGED,
+			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),
+		})
 
 	} else {
 		// Import pre-existing resources (LocalStack / production without suffix)

--- a/infra/stack/projectnotifierstack.go
+++ b/infra/stack/projectnotifierstack.go
@@ -104,7 +104,7 @@ func ProjectNotifierStack(scope constructs.Construct, id string, props *LambdaSt
 
 		bucket = awss3.NewBucket(stack, jsii.String("MessageTemplates"), &awss3.BucketProps{
 			BucketName:        jsii.String(bucketName),
-			RemovalPolicy:     awscdk.RemovalPolicy_DESTROY,
+			RemovalPolicy:     awscdk.RemovalPolicy_RETAIN,
 			Versioned:         jsii.Bool(true),
 			Encryption:        awss3.BucketEncryption_S3_MANAGED,
 			BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -44,7 +44,7 @@ var approvalRequestTmpl = template.Must(template.New("approval_request.html").Pa
 // WorkflowFailed returns the subject, plain text, and HTML body for a workflow step failure email.
 // errorMessage should be the human-readable error (already extracted from any JSON Cause blob).
 func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBody string, err error) {
-	subject = "NYC Cares Project Welcomer \u2014 Workflow Step Failed"
+	subject = "nycares Project Welcomer \u2014 Workflow Step Failed"
 
 	plainText = fmt.Sprintf("Workflow step failed.\nStep: %s\nError: %s", failedStep, errorMessage)
 
@@ -61,13 +61,13 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 }
 
 // ApprovalRequest returns the subject, plain text, and HTML body for a message approval email.
-// mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
+// mockMode indicates whether send/pin requests will go to the mock server or the real nycares platform.
 // regenerateLink triggers a fresh generation with no additional context (thankYou only).
 // refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement (thankYou only).
 func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, secret string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Project Message Approval"
 
-	destination := "real NYC Cares platform"
+	destination := "real nycares platform"
 	if mockMode {
 		destination = "mock server"
 	}
@@ -108,11 +108,11 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 }
 
 // Completion returns the subject, plain text, and HTML body for a successful message send notification.
-// mockMode indicates whether send/pin requests will go to the mock server or the real NYC Cares platform.
+// mockMode indicates whether send/pin requests will go to the mock server or the real nycares platform.
 func Completion(messageType, projectName, projectDate string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Message Sent!"
 
-	destination := "real NYC Cares platform"
+	destination := "real nycares platform"
 	if mockMode {
 		destination = "mock server"
 	}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -44,7 +44,7 @@ var approvalRequestTmpl = template.Must(template.New("approval_request.html").Pa
 // WorkflowFailed returns the subject, plain text, and HTML body for a workflow step failure email.
 // errorMessage should be the human-readable error (already extracted from any JSON Cause blob).
 func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBody string, err error) {
-	subject = "nycares Project Welcomer \u2014 Workflow Step Failed"
+	subject = "NYCares Project Welcomer \u2014 Workflow Step Failed"
 
 	plainText = fmt.Sprintf("Workflow step failed.\nStep: %s\nError: %s", failedStep, errorMessage)
 
@@ -61,13 +61,13 @@ func WorkflowFailed(failedStep, errorMessage string) (subject, plainText, htmlBo
 }
 
 // ApprovalRequest returns the subject, plain text, and HTML body for a message approval email.
-// mockMode indicates whether send/pin requests will go to the mock server or the real nycares platform.
+// mockMode indicates whether send/pin requests will go to the mock server or the real NYCares platform.
 // regenerateLink triggers a fresh generation with no additional context (thankYou only).
 // refineFormBase is the callback URL (with token and secret) used as the HTML form action for refinement (thankYou only).
 func ApprovalRequest(projectName, projectDate, messageType, messageContent, approveLink, rejectLink, regenerateLink, refineFormBase, secret string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Project Message Approval"
 
-	destination := "real nycares platform"
+	destination := "real NYCares platform"
 	if mockMode {
 		destination = "mock server"
 	}
@@ -112,7 +112,7 @@ func ApprovalRequest(projectName, projectDate, messageType, messageContent, appr
 func Completion(messageType, projectName, projectDate string, mockMode bool) (subject, plainText, htmlBody string, err error) {
 	subject = "Message Sent!"
 
-	destination := "real nycares platform"
+	destination := "real NYCares platform"
 	if mockMode {
 		destination = "mock server"
 	}

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -10,7 +10,7 @@ func TestWorkflowFailed_Subject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "NYC Cares Project Welcomer \u2014 Workflow Step Failed"
+	want := "nycares Project Welcomer \u2014 Workflow Step Failed"
 	if subject != want {
 		t.Errorf("subject = %q, want %q", subject, want)
 	}
@@ -138,10 +138,10 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plainText2, "real NYC Cares platform") {
+	if !strings.Contains(plainText2, "real nycares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
-	if !strings.Contains(htmlBody2, "real NYC Cares platform") {
+	if !strings.Contains(htmlBody2, "real nycares platform") {
 		t.Error("htmlBody should indicate real platform when mockMode=false")
 	}
 }
@@ -223,10 +223,10 @@ func TestCompletion_MockMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plainText2, "real NYC Cares platform") {
+	if !strings.Contains(plainText2, "real nycares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
-	if !strings.Contains(htmlBody2, "real NYC Cares platform") {
+	if !strings.Contains(htmlBody2, "real nycares platform") {
 		t.Error("htmlBody should indicate real platform when mockMode=false")
 	}
 }

--- a/internal/email/templates_test.go
+++ b/internal/email/templates_test.go
@@ -10,7 +10,7 @@ func TestWorkflowFailed_Subject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "nycares Project Welcomer \u2014 Workflow Step Failed"
+	want := "NYCares Project Welcomer \u2014 Workflow Step Failed"
 	if subject != want {
 		t.Errorf("subject = %q, want %q", subject, want)
 	}
@@ -138,10 +138,10 @@ func TestApprovalRequest_MockMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plainText2, "real nycares platform") {
+	if !strings.Contains(plainText2, "real NYCares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
-	if !strings.Contains(htmlBody2, "real nycares platform") {
+	if !strings.Contains(htmlBody2, "real NYCares platform") {
 		t.Error("htmlBody should indicate real platform when mockMode=false")
 	}
 }
@@ -223,10 +223,10 @@ func TestCompletion_MockMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plainText2, "real nycares platform") {
+	if !strings.Contains(plainText2, "real NYCares platform") {
 		t.Error("plainText should indicate real platform when mockMode=false")
 	}
-	if !strings.Contains(htmlBody2, "real nycares platform") {
+	if !strings.Contains(htmlBody2, "real NYCares platform") {
 		t.Error("htmlBody should indicate real platform when mockMode=false")
 	}
 }

--- a/internal/mockserver/CLAUDE.md
+++ b/internal/mockserver/CLAUDE.md
@@ -1,6 +1,6 @@
 # Mock Server
 
-Simulates the NYC Cares API for local development and CI. Runs as a plain HTTP server locally (`:3001`) or as a Lambda Function URL in the `-ci` environment.
+Simulates the nycares API for local development and CI. Runs as a plain HTTP server locally (`:3001`) or as a Lambda Function URL in the `-ci` environment.
 
 ## Endpoints
 

--- a/internal/mockserver/CLAUDE.md
+++ b/internal/mockserver/CLAUDE.md
@@ -1,6 +1,6 @@
 # Mock Server
 
-Simulates the nycares API for local development and CI. Runs as a plain HTTP server locally (`:3001`) or as a Lambda Function URL in the `-ci` environment.
+Simulates the NYCares API for local development and CI. Runs as a plain HTTP server locally (`:3001`) or as a Lambda Function URL in the `-ci` environment.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary

- Replaces all occurrences of "NYC Cares" and "New York Cares" with "nycares" across the codebase
- Affects source strings, comments, email templates, e2e feature descriptions, README, and CLAUDE.md files
- No logic changes — purely a naming consistency refactor

## Changes

- `internal/email/templates.go` — email subject and `destination` strings
- `internal/email/templates_test.go` — updated test assertions to match new strings
- `cmd/emailpreview/main.go` — error string in preview tool
- `infra/stack/projectnotifierstack.go` — inline comments
- `e2e/features/workflow.feature` — feature description
- `README.md` — title, description, project tree, config table
- `internal/mockserver/CLAUDE.md` / `CLAUDE.md` — doc comments

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)